### PR TITLE
fix: guard against non-iterable extensions in settings panel (fixes PlatformNetwork/bounty-challenge#21906)

### DIFF
--- a/src/components/extensions/ExtensionBisect.tsx
+++ b/src/components/extensions/ExtensionBisect.tsx
@@ -40,7 +40,7 @@ export const ExtensionBisect: Component<ExtensionBisectProps> = (props) => {
   // Get the found extension details
   const foundExtensionDetails = createMemo(() => {
     if (!state.foundExtension) return null;
-    return extensions.extensions().find(
+    return (extensions.extensions() || []).find(
       e => e.manifest.name === state.foundExtension
     );
   });

--- a/src/components/extensions/ExtensionMarketplace.tsx
+++ b/src/components/extensions/ExtensionMarketplace.tsx
@@ -84,7 +84,7 @@ export const ExtensionMarketplace: Component<ExtensionMarketplaceProps> = (props
 
   // Get list of installed extension names for comparison
   const installedNames = createMemo(() =>
-    new Set(extensions().map((ext) => ext.manifest.name))
+    new Set((extensions() || []).map((ext) => ext.manifest.name))
   );
 
   // Filter marketplace extensions based on search and category
@@ -114,7 +114,7 @@ export const ExtensionMarketplace: Component<ExtensionMarketplaceProps> = (props
 
   // Filter installed extensions based on search and category
   const filteredInstalled = createMemo(() => {
-    let exts = extensions();
+    let exts = extensions() || [];
     const query = searchQuery().toLowerCase();
 
     // Apply text search
@@ -418,7 +418,7 @@ export const ExtensionMarketplace: Component<ExtensionMarketplaceProps> = (props
               "border-radius": "var(--cortex-radius-full)",
             }}
           >
-            {extensions().length}
+            {(extensions() || []).length}
           </span>
         </button>
       </div>

--- a/src/components/extensions/ExtensionPackView.tsx
+++ b/src/components/extensions/ExtensionPackView.tsx
@@ -115,7 +115,7 @@ export const ExtensionPackView: Component<ExtensionPackViewProps> = (props) => {
     const currentPack = pack();
     if (!currentPack) return [];
 
-    const installedExtensions = extensions();
+    const installedExtensions = extensions() || [];
 
     return currentPack.extensionIds.map((id) => {
       const ext = installedExtensions.find((e) => e.manifest.name === id);

--- a/src/components/extensions/ExtensionProfiler.tsx
+++ b/src/components/extensions/ExtensionProfiler.tsx
@@ -70,8 +70,8 @@ export const ExtensionProfiler: Component<ExtensionProfilerProps> = (props) => {
 
   // Build profiles from runtime state
   const buildProfiles = (): ExtensionProfile[] => {
-    const runtimeStates = runtime.extensions();
-    const enabledExts = enabledExtensions();
+    const runtimeStates = runtime.extensions() || [];
+    const enabledExts = enabledExtensions() || [];
 
     return runtimeStates.map((state) => {
       const ext = enabledExts.find((e) => e.manifest.name === state.id);

--- a/src/components/extensions/ExtensionRuntimeStatus.tsx
+++ b/src/components/extensions/ExtensionRuntimeStatus.tsx
@@ -86,7 +86,7 @@ export const RuntimeStatusBadge: Component<RuntimeStatusBadgeProps> = (props) =>
 
   // Get runtime state for this extension
   const runtimeState = createMemo(() => {
-    return runtime.extensions().find((s) => s.id === props.extensionId);
+    return (runtime.extensions() || []).find((s) => s.id === props.extensionId);
   });
 
   // Determine display status
@@ -266,7 +266,7 @@ export const RuntimeStatusSummary: Component = () => {
   const runtime = useExtensionRuntime();
 
   const stats = createMemo(() => {
-    const states = runtime.extensions();
+    const states = runtime.extensions() || [];
     const active = states.filter(
       (s) => s.status === ExtensionStatus.Active
     ).length;

--- a/src/components/extensions/ExtensionsPanel.tsx
+++ b/src/components/extensions/ExtensionsPanel.tsx
@@ -71,7 +71,7 @@ export const ExtensionsPanel: Component<ExtensionsPanelProps> = (props) => {
       return [];
     }
 
-    let exts = extensions();
+    let exts = extensions() || [];
     const query = searchQuery().toLowerCase();
 
     // Apply text search
@@ -204,7 +204,7 @@ export const ExtensionsPanel: Component<ExtensionsPanelProps> = (props) => {
           <h2 style={{ margin: 0, "font-size": "16px", "font-weight": 600 }}>
             Extensions
           </h2>
-          <Badge size="md">{extensions().length}</Badge>
+          <Badge size="md">{(extensions() || []).length}</Badge>
           {/* Updates available badge */}
           <Show when={outdatedCount() > 0}>
             <div 

--- a/src/components/extensions/PluginManager.tsx
+++ b/src/components/extensions/PluginManager.tsx
@@ -162,7 +162,7 @@ export const PluginManager: Component<PluginManagerProps> = (props) => {
   };
 
   const metricsInfo = () => {
-    const exts = extensions();
+    const exts = extensions() || [];
     const withTime = exts.filter((e) => e.activationTime != null);
     if (withTime.length === 0) return null;
     const avg = withTime.reduce((s, e) => s + e.activationTime!, 0) / withTime.length;
@@ -227,13 +227,13 @@ export const PluginManager: Component<PluginManagerProps> = (props) => {
         </div>
       </Show>
 
-      <Show when={!loading() && !error() && extensions().length === 0}>
+      <Show when={!loading() && !error() && (extensions() || []).length === 0}>
         <EmptyState icon="puzzle-piece" title="No extensions installed" description="Install extensions from the marketplace to get started." />
       </Show>
 
-      <Show when={!loading() && !error() && extensions().length > 0}>
+      <Show when={!loading() && !error() && (extensions() || []).length > 0}>
         <div class="flex-1 overflow-y-auto">
-          <For each={extensions()}>
+          <For each={extensions() || []}>
             {(ext) => {
               const busy = () => busyIds().has(ext.id);
               return (


### PR DESCRIPTION
## Fix for PlatformNetwork/bounty-challenge#21906: Extensions 'currentExtensions is not iterable' crash

### Changes
- Added `|| []` fallback guard on all `extensions()` calls across 7 extension-related files
- Ensures the UI doesn't crash when extensions signal returns `undefined` or `null`

### Files Modified
- `src/components/extensions/ExtensionsPanel.tsx`
- `src/components/extensions/ExtensionBisect.tsx`
- `src/components/extensions/ExtensionMarketplace.tsx`
- `src/components/extensions/ExtensionPackView.tsx`
- `src/components/extensions/ExtensionProfiler.tsx`
- `src/components/extensions/ExtensionRuntimeStatus.tsx`
- `src/components/extensions/PluginManager.tsx`