### PR TITLE
fix: remove duplicate Command Palette rendering (fixes PlatformNetwork/bounty-challenge#21923)

### DIFF
--- a/src/AppCore.tsx
+++ b/src/AppCore.tsx
@@ -54,7 +54,6 @@ const ToastManager = lazy(() => import("@/components/ToastManager").then(m => ({
 const NotificationCenter = lazy(() => import("@/components/NotificationCenter").then(m => ({ default: m.NotificationCenter })));
 
 // COMMAND PALETTE - Core UI, should load early
-const CommandPalette = lazy(() => import("@/components/CommandPalette").then(m => ({ default: m.CommandPalette })));
 const ViewQuickAccess = lazy(() => import("@/components/ViewQuickAccess").then(m => ({ default: m.ViewQuickAccess })));
 const PaletteCommandPalette = lazy(() => import("@/components/palette/CommandPalette").then(m => ({ default: m.PaletteCommandPalette })));
 const PaletteQuickOpen = lazy(() => import("@/components/palette/QuickOpen").then(m => ({ default: m.PaletteQuickOpen })));
@@ -568,7 +567,6 @@ function AppContent(props: ParentProps) {
         <Suspense>
           <ToastManager />
           <NotificationCenter />
-          <CommandPalette />
           <PaletteCommandPalette />
           <PaletteQuickOpen />
           <ViewQuickAccess />

--- a/src/components/palette/CommandPalette.tsx
+++ b/src/components/palette/CommandPalette.tsx
@@ -159,8 +159,9 @@ export function PaletteCommandPalette() {
   };
 
   const handleGlobalEsc = (e: KeyboardEvent) => { if (e.key === "Escape" && showCommandPalette()) { e.preventDefault(); setShowCommandPalette(false); } };
-  onMount(() => window.addEventListener("keydown", handleGlobalEsc));
-  onCleanup(() => window.removeEventListener("keydown", handleGlobalEsc));
+  const handleToggleEvent = () => { setShowCommandPalette(!showCommandPalette()); };
+  onMount(() => { window.addEventListener("keydown", handleGlobalEsc); window.addEventListener("command-palette:toggle", handleToggleEvent); });
+  onCleanup(() => { window.removeEventListener("keydown", handleGlobalEsc); window.removeEventListener("command-palette:toggle", handleToggleEvent); });
 
   const itemStyle = (sel: boolean): JSX.CSSProperties => ({
     display: "flex", "align-items": "center", gap: "6px", height: "24px", padding: "0 8px", margin: "1px 4px",


### PR DESCRIPTION
## Fix for PlatformNetwork/bounty-challenge#21923: Duplicate Command Palette rendering

### Changes
- Removed the old `CommandPalette` lazy import and its `<CommandPalette />` render from `AppCore.tsx`
- Only `PaletteCommandPalette` is now rendered (the newer, enhanced version)
- Added `command-palette:toggle` event listener to `PaletteCommandPalette` to preserve toggle functionality that was previously handled by the old component

### Files Modified
- `src/AppCore.tsx`
- `src/components/palette/CommandPalette.tsx`