### PR TITLE
fix: folder scope in Settings now correctly reads/writes folder-specific settings (fixes PlatformNetwork/bounty-challenge#21930)

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1050,7 +1050,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
                 <div style={{ display: "flex", "flex-direction": "column", gap: "24px" }}>
                   <SectionHeader 
                     title="General" 
-                    description={settingsScope() === "workspace" ? "Override theme for this workspace" : "General application settings"}
+                    description={settingsScope() === "workspace" ? "Override theme for this workspace" : settingsScope() === "folder" ? "Override theme for this folder" : "General application settings"}
                     icon={<Icon name="desktop" class="h-4 w-4" />}
                   />
                   <div>
@@ -1058,14 +1058,21 @@ export function SettingsDialog(props: SettingsDialogProps) {
                     <div style={{ display: "flex", gap: "8px" }}>
                       <For each={themes}>
                         {(t) => {
-                          const hasOverride = () => settings.hasWorkspaceOverride("theme", "theme");
+                          const hasOverride = () => {
+                            if (settingsScope() === "folder" && selectedFolder()) {
+                              return settings.hasFolderOverride(selectedFolder()!, "theme", "theme");
+                            }
+                            return settings.hasWorkspaceOverride("theme", "theme");
+                          };
                           const isSelected = () => safeThemeSettings(settings.effectiveSettings()).theme === t.value;
                           
                           return (
                             <div style={{ position: "relative" }}>
                               <UIButton
                                 onClick={() => {
-                                  if (settingsScope() === "workspace") {
+                                  if (settingsScope() === "folder" && selectedFolder()) {
+                                    settings.setFolderSetting(selectedFolder()!, "theme", "theme", t.value);
+                                  } else if (settingsScope() === "workspace") {
                                     settings.setWorkspaceSetting("theme", "theme", t.value);
                                   } else {
                                     setTheme(t.value);
@@ -1095,7 +1102,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
                     </div>
                   </div>
                   
-                  {/* Reset workspace theme override */}
+                  {/* Reset workspace/folder theme override */}
                   <Show when={settingsScope() === "workspace" && settings.hasWorkspaceOverride("theme", "theme")}>
                     <UIButton
                       onClick={() => settings.resetWorkspaceSetting("theme", "theme")}
@@ -1105,6 +1112,17 @@ export function SettingsDialog(props: SettingsDialogProps) {
                       style={{ color: "var(--cortex-info)" }}
                     >
                       Reset to user theme
+                    </UIButton>
+                  </Show>
+                  <Show when={settingsScope() === "folder" && selectedFolder() && settings.hasFolderOverride(selectedFolder()!, "theme", "theme")}>
+                    <UIButton
+                      onClick={() => settings.resetFolderSetting(selectedFolder()!, "theme", "theme")}
+                      variant="ghost"
+                      size="sm"
+                      icon={<Icon name="rotate-left" style={{ width: "12px", height: "12px" }} />}
+                      style={{ color: "var(--cortex-success)" }}
+                    >
+                      Reset to workspace/user theme
                     </UIButton>
                   </Show>
 
@@ -1119,7 +1137,9 @@ export function SettingsDialog(props: SettingsDialogProps) {
                         selected={safeThemeSettings(settings.effectiveSettings()).wrapTabs}
                         onSelect={async () => {
                           const currentValue = safeThemeSettings(settings.effectiveSettings()).wrapTabs;
-                          if (settingsScope() === "workspace") {
+                          if (settingsScope() === "folder" && selectedFolder()) {
+                            await settings.setFolderSetting(selectedFolder()!, "theme", "wrapTabs", !currentValue);
+                          } else if (settingsScope() === "workspace") {
                             await settings.setWorkspaceSetting("theme", "wrapTabs", !currentValue);
                           } else {
                             await settings.updateThemeSetting("wrapTabs", !currentValue);
@@ -1128,7 +1148,10 @@ export function SettingsDialog(props: SettingsDialogProps) {
                         title="Wrap Tabs"
                         description="When enabled, tabs wrap to multiple lines instead of showing scroll buttons"
                       />
-                      <Show when={settings.hasWorkspaceOverride("theme", "wrapTabs")}>
+                      <Show when={
+                        (settingsScope() === "folder" && selectedFolder() && settings.hasFolderOverride(selectedFolder()!, "theme", "wrapTabs")) ||
+                        (settingsScope() !== "folder" && settings.hasWorkspaceOverride("theme", "wrapTabs"))
+                      }>
                         <span style={{
                           position: "absolute",
                           top: "8px",
@@ -1136,13 +1159,13 @@ export function SettingsDialog(props: SettingsDialogProps) {
                           width: "8px",
                           height: "8px",
                           "border-radius": "var(--cortex-radius-full)",
-                          background: "var(--cortex-info)",
+                          background: settingsScope() === "folder" ? "var(--cortex-success)" : "var(--cortex-info)",
                         }} />
                       </Show>
                     </div>
                   </div>
                   
-                  {/* Reset workspace wrapTabs override */}
+                  {/* Reset workspace/folder wrapTabs override */}
                   <Show when={settingsScope() === "workspace" && settings.hasWorkspaceOverride("theme", "wrapTabs")}>
                     <UIButton
                       onClick={() => settings.resetWorkspaceSetting("theme", "wrapTabs")}
@@ -1152,6 +1175,17 @@ export function SettingsDialog(props: SettingsDialogProps) {
                       style={{ color: "var(--cortex-info)" }}
                     >
                       Reset to user setting
+                    </UIButton>
+                  </Show>
+                  <Show when={settingsScope() === "folder" && selectedFolder() && settings.hasFolderOverride(selectedFolder()!, "theme", "wrapTabs")}>
+                    <UIButton
+                      onClick={() => settings.resetFolderSetting(selectedFolder()!, "theme", "wrapTabs")}
+                      variant="ghost"
+                      size="sm"
+                      icon={<Icon name="rotate-left" style={{ width: "12px", height: "12px" }} />}
+                      style={{ color: "var(--cortex-success)" }}
+                    >
+                      Reset to workspace/user setting
                     </UIButton>
                   </Show>
 
@@ -1202,7 +1236,9 @@ export function SettingsDialog(props: SettingsDialogProps) {
                       <Select
                         value={safeExplorerSettings(settings.effectiveSettings()).sortOrder}
                         onChange={async (value) => {
-                          if (settingsScope() === "workspace") {
+                          if (settingsScope() === "folder" && selectedFolder()) {
+                            await settings.setFolderSetting(selectedFolder()!, "explorer", "sortOrder", value as ExplorerSortOrder);
+                          } else if (settingsScope() === "workspace") {
                             await settings.setWorkspaceSetting("explorer", "sortOrder", value as ExplorerSortOrder);
                           } else {
                             await settings.updateExplorerSetting("sortOrder", value as ExplorerSortOrder);
@@ -1219,7 +1255,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
                       />
                     </FormGroup>
                     
-                    {/* Reset workspace sort order override */}
+                    {/* Reset workspace/folder sort order override */}
                     <Show when={settingsScope() === "workspace" && settings.hasWorkspaceOverride("explorer", "sortOrder")}>
                       <UIButton
                         onClick={() => settings.resetWorkspaceSetting("explorer", "sortOrder")}
@@ -1229,6 +1265,17 @@ export function SettingsDialog(props: SettingsDialogProps) {
                       style={{ color: "var(--cortex-info)", "margin-top": "8px" }}
                     >
                       Reset to user setting
+                    </UIButton>
+                  </Show>
+                  <Show when={settingsScope() === "folder" && selectedFolder() && settings.hasFolderOverride(selectedFolder()!, "explorer", "sortOrder")}>
+                      <UIButton
+                        onClick={() => settings.resetFolderSetting(selectedFolder()!, "explorer", "sortOrder")}
+                        variant="ghost"
+                        size="sm"
+                      icon={<Icon name="rotate-left" style={{ width: "12px", height: "12px" }} />}
+                      style={{ color: "var(--cortex-success)", "margin-top": "8px" }}
+                    >
+                      Reset to workspace/user setting
                     </UIButton>
                   </Show>
                 </div>
@@ -1244,7 +1291,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
                     description="File associations, auto save, and formatting settings"
                     icon={<Icon name="file-lines" class="h-4 w-4" />}
                   />
-                  <FilesSettingsPanel scope={settingsScope()} />
+                  <FilesSettingsPanel scope={settingsScope()} folderPath={settingsScope() === "folder" ? selectedFolder() || undefined : undefined} />
                 </div>
               </div>
 
@@ -1358,7 +1405,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
                   icon={<Icon name="globe" class="h-4 w-4" />}
                 />
                 <div style={{ "margin-top": "16px" }}>
-                  <NetworkSettingsPanel scope={settingsScope()} />
+                  <NetworkSettingsPanel scope={settingsScope()} folderPath={settingsScope() === "folder" ? selectedFolder() || undefined : undefined} />
                 </div>
               </div>
 
@@ -1422,7 +1469,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
                   <div class="border-t border-border my-6" />
 
                   {/* Full Editor Settings Panel */}
-                  <EditorSettingsPanel scope={settingsScope()} />
+                  <EditorSettingsPanel scope={settingsScope()} folderPath={settingsScope() === "folder" ? selectedFolder() || undefined : undefined} />
                 </div>
               </div>
 
@@ -1631,7 +1678,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
                   icon={<Icon name="terminal" class="h-4 w-4" />}
                 />
                 <div style={{ "margin-top": "16px" }}>
-                  <TerminalSettingsPanel scope={settingsScope()} />
+                  <TerminalSettingsPanel scope={settingsScope()} folderPath={settingsScope() === "folder" ? selectedFolder() || undefined : undefined} />
                 </div>
               </div>
 
@@ -1643,7 +1690,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
                   icon={<Icon name="code-branch" class="h-4 w-4" />}
                 />
                 <div style={{ "margin-top": "16px" }}>
-                  <GitSettingsPanel scope={settingsScope()} />
+                  <GitSettingsPanel scope={settingsScope()} folderPath={settingsScope() === "folder" ? selectedFolder() || undefined : undefined} />
                 </div>
               </div>
 
@@ -1655,7 +1702,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
                   icon={<Icon name="bug" class="h-4 w-4" />}
                 />
                 <div style={{ "margin-top": "16px" }}>
-                  <DebugSettingsPanel scope={settingsScope()} />
+                  <DebugSettingsPanel scope={settingsScope()} folderPath={settingsScope() === "folder" ? selectedFolder() || undefined : undefined} />
                 </div>
               </div>
 

--- a/src/components/settings/DebugSettingsPanel.tsx
+++ b/src/components/settings/DebugSettingsPanel.tsx
@@ -5,6 +5,7 @@ import { Icon } from "../ui/Icon";
 
 interface DebugSettingsPanelProps {
   scope?: SettingsScope;
+  folderPath?: string;
 }
 
 /** Row with workspace override indicator and modified from default indicator */
@@ -79,26 +80,42 @@ export function DebugSettingsPanel(props: DebugSettingsPanelProps) {
   const scope = () => props.scope || "user";
   
   // Use effective settings for display, but update based on scope
-  const debug = () => settings.effectiveSettings().debug;
+  const debug = () => {
+    if (scope() === "folder" && props.folderPath) {
+      return settings.getEffectiveSettingsForPath(props.folderPath).debug;
+    }
+    return settings.effectiveSettings().debug;
+  };
   
   // Helper to update setting based on current scope
   const updateSetting = <K extends keyof DebugSettings>(key: K, value: DebugSettings[K]) => {
-    if (scope() === "workspace" && settings.hasWorkspace()) {
+    if (scope() === "folder" && props.folderPath) {
+      settings.setFolderSetting(props.folderPath, "debug", key, value);
+    } else if (scope() === "workspace" && settings.hasWorkspace()) {
       settings.setWorkspaceSetting("debug", key, value);
     } else {
       settings.updateDebugSetting(key, value);
     }
   };
 
-  // Check if setting has workspace override
-  const hasOverride = (key: keyof DebugSettings) => settings.hasWorkspaceOverride("debug", key);
+  // Check if setting has workspace or folder override
+  const hasOverride = (key: keyof DebugSettings) => {
+    if (scope() === "folder" && props.folderPath) {
+      return settings.hasFolderOverride(props.folderPath, "debug", key);
+    }
+    return settings.hasWorkspaceOverride("debug", key);
+  };
   
   // Check if setting is modified from default
   const isModified = (key: keyof DebugSettings) => settings.isSettingModified("debug", key);
   
-  // Reset workspace override
+  // Reset workspace or folder override
   const resetOverride = (key: keyof DebugSettings) => {
-    settings.resetWorkspaceSetting("debug", key);
+    if (scope() === "folder" && props.folderPath) {
+      settings.resetFolderSetting(props.folderPath, "debug", key);
+    } else {
+      settings.resetWorkspaceSetting("debug", key);
+    }
   };
   
   // Reset setting to default value
@@ -128,6 +145,11 @@ export function DebugSettingsPanel(props: DebugSettingsPanelProps) {
       <Show when={scope() === "workspace"}>
         <div class="text-xs text-purple-400 bg-purple-500/10 rounded-lg px-3 py-2 mb-4">
           Editing workspace-specific debug settings. Changes apply only to this workspace.
+        </div>
+      </Show>
+      <Show when={scope() === "folder" && props.folderPath}>
+        <div class="text-xs text-green-400 bg-green-500/10 rounded-lg px-3 py-2 mb-4">
+          Editing folder-specific debug settings. Changes apply only to this folder.
         </div>
       </Show>
 
@@ -298,7 +320,7 @@ export function DebugSettingsPanel(props: DebugSettingsPanelProps) {
                 });
               }}
             >
-              Reset All Workspace Debug Overrides
+              {scope() === "folder" ? "Reset All Folder Debug Overrides" : "Reset All Workspace Debug Overrides"}
             </Button>
           }
         >

--- a/src/components/settings/EditorSettingsPanel.tsx
+++ b/src/components/settings/EditorSettingsPanel.tsx
@@ -10,6 +10,7 @@ import { tokens } from '@/design-system/tokens';
 
 interface EditorSettingsPanelProps {
   scope?: SettingsScope;
+  folderPath?: string;
 }
 
 /** Row with workspace override indicator and modified from default indicator */
@@ -136,26 +137,42 @@ export function EditorSettingsPanel(props: EditorSettingsPanelProps) {
   const scope = () => props.scope || "user";
   
   // Use effective settings for display, but update based on scope
-  const editor = () => settings.effectiveSettings().editor;
+  const editor = () => {
+    if (scope() === "folder" && props.folderPath) {
+      return settings.getEffectiveSettingsForPath(props.folderPath).editor;
+    }
+    return settings.effectiveSettings().editor;
+  };
   
   // Helper to update setting based on current scope
   const updateSetting = <K extends keyof EditorSettings>(key: K, value: EditorSettings[K]) => {
-    if (scope() === "workspace" && settings.hasWorkspace()) {
+    if (scope() === "folder" && props.folderPath) {
+      settings.setFolderSetting(props.folderPath, "editor", key, value);
+    } else if (scope() === "workspace" && settings.hasWorkspace()) {
       settings.setWorkspaceSetting("editor", key, value);
     } else {
       settings.updateEditorSetting(key, value);
     }
   };
 
-  // Check if setting has workspace override
-  const hasOverride = (key: keyof EditorSettings) => settings.hasWorkspaceOverride("editor", key);
+  // Check if setting has workspace or folder override
+  const hasOverride = (key: keyof EditorSettings) => {
+    if (scope() === "folder" && props.folderPath) {
+      return settings.hasFolderOverride(props.folderPath, "editor", key);
+    }
+    return settings.hasWorkspaceOverride("editor", key);
+  };
   
   // Check if setting is modified from default
   const isModified = (key: keyof EditorSettings) => settings.isSettingModified("editor", key);
   
-  // Reset workspace override
+  // Reset workspace or folder override
   const resetOverride = (key: keyof EditorSettings) => {
-    settings.resetWorkspaceSetting("editor", key);
+    if (scope() === "folder" && props.folderPath) {
+      settings.resetFolderSetting(props.folderPath, "editor", key);
+    } else {
+      settings.resetWorkspaceSetting("editor", key);
+    }
   };
   
   // Reset setting to default value
@@ -296,6 +313,19 @@ export function EditorSettingsPanel(props: EditorSettingsPanelProps) {
           "margin-bottom": "16px",
         }}>
           Editing workspace-specific editor settings. Changes apply only to this workspace.
+        </Badge>
+      </Show>
+      <Show when={scope() === "folder" && props.folderPath}>
+        <Badge variant="accent" style={{ 
+          padding: `${tokens.spacing.md} ${tokens.spacing.lg}`, 
+          "font-size": "var(--jb-text-muted-size)",
+          "border-radius": "var(--jb-radius-lg)",
+          "margin-bottom": "16px",
+          background: "rgba(16, 185, 129, 0.1)",
+          color: "rgb(16, 185, 129)",
+          border: "1px solid rgba(16, 185, 129, 0.3)",
+        }}>
+          Editing folder-specific editor settings. Changes apply only to files in this folder.
         </Badge>
       </Show>
 
@@ -1159,7 +1189,7 @@ export function EditorSettingsPanel(props: EditorSettingsPanelProps) {
                 });
               }}
             >
-              Reset All Workspace Editor Overrides
+              {scope() === "folder" ? "Reset All Folder Editor Overrides" : "Reset All Workspace Editor Overrides"}
             </Button>
           }
         >

--- a/src/components/settings/FilesSettingsPanel.tsx
+++ b/src/components/settings/FilesSettingsPanel.tsx
@@ -5,6 +5,7 @@ import { Icon } from "../ui/Icon";
 
 interface FilesSettingsPanelProps {
   scope?: SettingsScope;
+  folderPath?: string;
 }
 
 // Monaco language options - commonly used languages sorted alphabetically
@@ -386,20 +387,36 @@ export function FilesSettingsPanel(props: FilesSettingsPanelProps) {
   const settings = useSettings();
   const scope = () => props.scope || "user";
   
-  const files = () => settings.effectiveSettings().files;
+  const files = () => {
+    if (scope() === "folder" && props.folderPath) {
+      return settings.getEffectiveSettingsForPath(props.folderPath).files;
+    }
+    return settings.effectiveSettings().files;
+  };
   
   const updateSetting = <K extends keyof FilesSettings>(key: K, value: FilesSettings[K]) => {
-    if (scope() === "workspace" && settings.hasWorkspace()) {
+    if (scope() === "folder" && props.folderPath) {
+      settings.setFolderSetting(props.folderPath, "files", key, value);
+    } else if (scope() === "workspace" && settings.hasWorkspace()) {
       settings.setWorkspaceSetting("files", key, value);
     } else {
       settings.updateFilesSetting(key, value);
     }
   };
 
-  const hasOverride = (key: keyof FilesSettings) => settings.hasWorkspaceOverride("files", key);
+  const hasOverride = (key: keyof FilesSettings) => {
+    if (scope() === "folder" && props.folderPath) {
+      return settings.hasFolderOverride(props.folderPath, "files", key);
+    }
+    return settings.hasWorkspaceOverride("files", key);
+  };
   const isModified = (key: keyof FilesSettings) => settings.isSettingModified("files", key);
   const resetOverride = (key: keyof FilesSettings) => {
-    settings.resetWorkspaceSetting("files", key);
+    if (scope() === "folder" && props.folderPath) {
+      settings.resetFolderSetting(props.folderPath, "files", key);
+    } else {
+      settings.resetWorkspaceSetting("files", key);
+    }
   };
   const resetToDefault = (key: keyof FilesSettings) => {
     settings.resetSettingToDefault("files", key);
@@ -422,14 +439,21 @@ export function FilesSettingsPanel(props: FilesSettingsPanelProps) {
   };
 
   // Search exclude patterns
-  const search = () => settings.effectiveSettings().search;
+  const search = () => {
+    if (scope() === "folder" && props.folderPath) {
+      return settings.getEffectiveSettingsForPath(props.folderPath).search;
+    }
+    return settings.effectiveSettings().search;
+  };
   const searchExcludePatterns = createMemo(() => {
     const exclude = search().exclude || {};
     return Object.entries(exclude).sort((a, b) => a[0].localeCompare(b[0]));
   });
 
   const updateSearchSetting = <K extends keyof SearchSettings>(key: K, value: SearchSettings[K]) => {
-    if (scope() === "workspace" && settings.hasWorkspace()) {
+    if (scope() === "folder" && props.folderPath) {
+      settings.setFolderSetting(props.folderPath, "search", key, value);
+    } else if (scope() === "workspace" && settings.hasWorkspace()) {
       settings.setWorkspaceSetting("search", key, value);
     } else {
       settings.updateSearchSetting(key, value);
@@ -482,6 +506,11 @@ export function FilesSettingsPanel(props: FilesSettingsPanelProps) {
       <Show when={scope() === "workspace"}>
         <div class="text-xs text-purple-400 bg-purple-500/10 rounded-lg px-3 py-2 mb-4">
           Editing workspace-specific file settings. Changes apply only to this workspace.
+        </div>
+      </Show>
+      <Show when={scope() === "folder" && props.folderPath}>
+        <div class="text-xs text-green-400 bg-green-500/10 rounded-lg px-3 py-2 mb-4">
+          Editing folder-specific file settings. Changes apply only to files in this folder.
         </div>
       </Show>
 
@@ -823,7 +852,7 @@ export function FilesSettingsPanel(props: FilesSettingsPanelProps) {
                 });
               }}
             >
-              Reset All Workspace File Overrides
+              {scope() === "folder" ? "Reset All Folder File Overrides" : "Reset All Workspace File Overrides"}
             </Button>
           }
         >

--- a/src/components/settings/GitSettingsPanel.tsx
+++ b/src/components/settings/GitSettingsPanel.tsx
@@ -6,6 +6,7 @@ import { Icon } from "../ui/Icon";
 
 interface GitSettingsPanelProps {
   scope?: SettingsScope;
+  folderPath?: string;
 }
 
 /** Row with workspace override indicator */
@@ -174,26 +175,42 @@ export function GitSettingsPanel(props: GitSettingsPanelProps) {
   const scope = () => props.scope || "user";
   
   // Use effective settings for display
-  const git = () => settings.effectiveSettings().git;
+  const git = () => {
+    if (scope() === "folder" && props.folderPath) {
+      return settings.getEffectiveSettingsForPath(props.folderPath).git;
+    }
+    return settings.effectiveSettings().git;
+  };
 
   // Helper to update setting based on current scope
   const updateSetting = <K extends keyof GitSettings>(key: K, value: GitSettings[K]) => {
-    if (scope() === "workspace" && settings.hasWorkspace()) {
+    if (scope() === "folder" && props.folderPath) {
+      settings.setFolderSetting(props.folderPath, "git", key, value);
+    } else if (scope() === "workspace" && settings.hasWorkspace()) {
       settings.setWorkspaceSetting("git", key, value);
     } else {
       settings.updateSettings("git", { ...settings.userSettings().git, [key]: value });
     }
   };
 
-  // Check if setting has workspace override
-  const hasOverride = (key: keyof GitSettings) => settings.hasWorkspaceOverride("git", key);
+  // Check if setting has workspace or folder override
+  const hasOverride = (key: keyof GitSettings) => {
+    if (scope() === "folder" && props.folderPath) {
+      return settings.hasFolderOverride(props.folderPath, "git", key);
+    }
+    return settings.hasWorkspaceOverride("git", key);
+  };
   
   // Check if setting is modified from default
   const isModified = (key: keyof GitSettings) => settings.isSettingModified("git", key);
   
-  // Reset workspace override
+  // Reset workspace or folder override
   const resetOverride = (key: keyof GitSettings) => {
-    settings.resetWorkspaceSetting("git", key);
+    if (scope() === "folder" && props.folderPath) {
+      settings.resetFolderSetting(props.folderPath, "git", key);
+    } else {
+      settings.resetWorkspaceSetting("git", key);
+    }
   };
   
   // Reset to default value
@@ -218,6 +235,11 @@ export function GitSettingsPanel(props: GitSettingsPanelProps) {
       <Show when={scope() === "workspace"}>
         <div class="text-xs text-purple-400 bg-purple-500/10 rounded-lg px-3 py-2 mb-4">
           Editing workspace-specific Git settings. Changes apply only to this workspace.
+        </div>
+      </Show>
+      <Show when={scope() === "folder" && props.folderPath}>
+        <div class="text-xs text-green-400 bg-green-500/10 rounded-lg px-3 py-2 mb-4">
+          Editing folder-specific Git settings. Changes apply only to this folder.
         </div>
       </Show>
 
@@ -487,7 +509,7 @@ export function GitSettingsPanel(props: GitSettingsPanelProps) {
                 });
               }}
             >
-              Reset All Workspace Git Overrides
+              {scope() === "folder" ? "Reset All Folder Git Overrides" : "Reset All Workspace Git Overrides"}
             </Button>
           }
         >

--- a/src/components/settings/NetworkSettingsPanel.tsx
+++ b/src/components/settings/NetworkSettingsPanel.tsx
@@ -5,6 +5,7 @@ import { Icon } from "../ui/Icon";
 
 interface NetworkSettingsPanelProps {
   scope?: SettingsScope;
+  folderPath?: string;
 }
 
 /** Row with workspace override indicator */
@@ -86,23 +87,39 @@ export function NetworkSettingsPanel(props: NetworkSettingsPanelProps) {
   const scope = () => props.scope || "user";
   
   // Use effective settings for display
-  const http = () => settings.effectiveSettings().http;
+  const http = () => {
+    if (scope() === "folder" && props.folderPath) {
+      return settings.getEffectiveSettingsForPath(props.folderPath).http;
+    }
+    return settings.effectiveSettings().http;
+  };
 
   // Helper to update setting based on current scope
   const updateSetting = <K extends keyof HttpSettings>(key: K, value: HttpSettings[K]) => {
-    if (scope() === "workspace" && settings.hasWorkspace()) {
+    if (scope() === "folder" && props.folderPath) {
+      settings.setFolderSetting(props.folderPath, "http", key, value);
+    } else if (scope() === "workspace" && settings.hasWorkspace()) {
       settings.setWorkspaceSetting("http", key, value);
     } else {
       settings.updateHttpSetting(key, value);
     }
   };
 
-  // Check if setting has workspace override
-  const hasOverride = (key: keyof HttpSettings) => settings.hasWorkspaceOverride("http", key);
+  // Check if setting has workspace or folder override
+  const hasOverride = (key: keyof HttpSettings) => {
+    if (scope() === "folder" && props.folderPath) {
+      return settings.hasFolderOverride(props.folderPath, "http", key);
+    }
+    return settings.hasWorkspaceOverride("http", key);
+  };
   
-  // Reset workspace override
+  // Reset workspace or folder override
   const resetOverride = (key: keyof HttpSettings) => {
-    settings.resetWorkspaceSetting("http", key);
+    if (scope() === "folder" && props.folderPath) {
+      settings.resetFolderSetting(props.folderPath, "http", key);
+    } else {
+      settings.resetWorkspaceSetting("http", key);
+    }
   };
 
   const proxySupportOptions = [
@@ -117,6 +134,11 @@ export function NetworkSettingsPanel(props: NetworkSettingsPanelProps) {
       <Show when={scope() === "workspace"}>
         <div class="text-xs text-purple-400 bg-purple-500/10 rounded-lg px-3 py-2 mb-4">
           Editing workspace-specific network settings. Changes apply only to this workspace.
+        </div>
+      </Show>
+      <Show when={scope() === "folder" && props.folderPath}>
+        <div class="text-xs text-green-400 bg-green-500/10 rounded-lg px-3 py-2 mb-4">
+          Editing folder-specific network settings. Changes apply only to this folder.
         </div>
       </Show>
 
@@ -232,7 +254,7 @@ export function NetworkSettingsPanel(props: NetworkSettingsPanelProps) {
                 });
               }}
             >
-              Reset All Workspace Network Overrides
+              {scope() === "folder" ? "Reset All Folder Network Overrides" : "Reset All Workspace Network Overrides"}
             </Button>
           }
         >

--- a/src/components/settings/TerminalSettingsPanel.tsx
+++ b/src/components/settings/TerminalSettingsPanel.tsx
@@ -7,6 +7,7 @@ import { TERMINAL_THEMES, getTerminalThemeDefinition } from "@/lib/terminalTheme
 
 interface TerminalSettingsPanelProps {
   scope?: SettingsScope;
+  folderPath?: string;
 }
 
 /** Row with workspace override indicator */
@@ -88,7 +89,12 @@ export function TerminalSettingsPanel(props: TerminalSettingsPanelProps) {
   const scope = () => props.scope || "user";
   
   // Use effective settings for display
-  const terminal = () => settings.effectiveSettings().terminal;
+  const terminal = () => {
+    if (scope() === "folder" && props.folderPath) {
+      return settings.getEffectiveSettingsForPath(props.folderPath).terminal;
+    }
+    return settings.effectiveSettings().terminal;
+  };
   const [defaultShell, setDefaultShell] = createSignal("");
 
   onMount(async () => {
@@ -102,19 +108,30 @@ export function TerminalSettingsPanel(props: TerminalSettingsPanelProps) {
 
   // Helper to update setting based on current scope
   const updateSetting = <K extends keyof TerminalSettings>(key: K, value: TerminalSettings[K]) => {
-    if (scope() === "workspace" && settings.hasWorkspace()) {
+    if (scope() === "folder" && props.folderPath) {
+      settings.setFolderSetting(props.folderPath, "terminal", key, value);
+    } else if (scope() === "workspace" && settings.hasWorkspace()) {
       settings.setWorkspaceSetting("terminal", key, value);
     } else {
       settings.updateTerminalSetting(key, value);
     }
   };
 
-  // Check if setting has workspace override
-  const hasOverride = (key: keyof TerminalSettings) => settings.hasWorkspaceOverride("terminal", key);
+  // Check if setting has workspace or folder override
+  const hasOverride = (key: keyof TerminalSettings) => {
+    if (scope() === "folder" && props.folderPath) {
+      return settings.hasFolderOverride(props.folderPath, "terminal", key);
+    }
+    return settings.hasWorkspaceOverride("terminal", key);
+  };
   
-  // Reset workspace override
+  // Reset workspace or folder override
   const resetOverride = (key: keyof TerminalSettings) => {
-    settings.resetWorkspaceSetting("terminal", key);
+    if (scope() === "folder" && props.folderPath) {
+      settings.resetFolderSetting(props.folderPath, "terminal", key);
+    } else {
+      settings.resetWorkspaceSetting("terminal", key);
+    }
   };
 
   const fontFamilyOptions = [
@@ -172,6 +189,11 @@ export function TerminalSettingsPanel(props: TerminalSettingsPanelProps) {
       <Show when={scope() === "workspace"}>
         <div class="text-xs text-purple-400 bg-purple-500/10 rounded-lg px-3 py-2 mb-4">
           Editing workspace-specific terminal settings. Changes apply only to this workspace.
+        </div>
+      </Show>
+      <Show when={scope() === "folder" && props.folderPath}>
+        <div class="text-xs text-green-400 bg-green-500/10 rounded-lg px-3 py-2 mb-4">
+          Editing folder-specific terminal settings. Changes apply only to this folder.
         </div>
       </Show>
 
@@ -513,7 +535,7 @@ export function TerminalSettingsPanel(props: TerminalSettingsPanelProps) {
                 });
               }}
             >
-              Reset All Workspace Terminal Overrides
+              {scope() === "folder" ? "Reset All Folder Terminal Overrides" : "Reset All Workspace Terminal Overrides"}
             </Button>
           }
         >

--- a/src/components/settings/WorkbenchSettingsPanel.tsx
+++ b/src/components/settings/WorkbenchSettingsPanel.tsx
@@ -5,6 +5,7 @@ import { Icon } from "../ui/Icon";
 
 interface WorkbenchSettingsPanelProps {
   scope?: SettingsScope;
+  folderPath?: string;
 }
 
 // ============================================================================
@@ -222,26 +223,42 @@ export function WorkbenchSettingsPanel(props: WorkbenchSettingsPanelProps) {
   const scope = () => props.scope || "user";
   
   // Use effective settings for display, but update based on scope
-  const theme = () => settings.effectiveSettings().theme;
+  const theme = () => {
+    if (scope() === "folder" && props.folderPath) {
+      return settings.getEffectiveSettingsForPath(props.folderPath).theme;
+    }
+    return settings.effectiveSettings().theme;
+  };
   
   // Helper to update setting based on current scope
   const updateSetting = <K extends keyof ThemeSettings>(key: K, value: ThemeSettings[K]) => {
-    if (scope() === "workspace" && settings.hasWorkspace()) {
+    if (scope() === "folder" && props.folderPath) {
+      settings.setFolderSetting(props.folderPath, "theme", key, value);
+    } else if (scope() === "workspace" && settings.hasWorkspace()) {
       settings.setWorkspaceSetting("theme", key, value);
     } else {
       settings.updateThemeSetting(key, value);
     }
   };
 
-  // Check if setting has workspace override
-  const hasOverride = (key: keyof ThemeSettings) => settings.hasWorkspaceOverride("theme", key);
+  // Check if setting has workspace or folder override
+  const hasOverride = (key: keyof ThemeSettings) => {
+    if (scope() === "folder" && props.folderPath) {
+      return settings.hasFolderOverride(props.folderPath, "theme", key);
+    }
+    return settings.hasWorkspaceOverride("theme", key);
+  };
   
   // Check if setting is modified from default
   const isModified = (key: keyof ThemeSettings) => settings.isSettingModified("theme", key);
   
-  // Reset workspace override
+  // Reset workspace or folder override
   const resetOverride = (key: keyof ThemeSettings) => {
-    settings.resetWorkspaceSetting("theme", key);
+    if (scope() === "folder" && props.folderPath) {
+      settings.resetFolderSetting(props.folderPath, "theme", key);
+    } else {
+      settings.resetWorkspaceSetting("theme", key);
+    }
   };
   
   // Reset setting to default value
@@ -285,6 +302,11 @@ export function WorkbenchSettingsPanel(props: WorkbenchSettingsPanelProps) {
       <Show when={scope() === "workspace"}>
         <div class="text-xs text-purple-400 bg-purple-500/10 rounded-lg px-3 py-2 mb-4">
           Editing workspace-specific workbench settings. Changes apply only to this workspace.
+        </div>
+      </Show>
+      <Show when={scope() === "folder" && props.folderPath}>
+        <div class="text-xs text-green-400 bg-green-500/10 rounded-lg px-3 py-2 mb-4">
+          Editing folder-specific workbench settings. Changes apply only to this folder.
         </div>
       </Show>
 


### PR DESCRIPTION
## Fix for PlatformNetwork/bounty-challenge#21930: Folder-scoped settings not wired in Settings Dialog

### Changes
- Added `setFolderSetting` and `resetFolderSetting` functions to settings panels
- All 8 settings panels now accept `scope` and `folderPath` props
- When scope is 'folder', settings are read from and written to folder-specific overrides
- SettingsDialog passes the correct scope and folderPath to all panel components

### Files Modified
- `src/components/SettingsDialog.tsx`
- `src/components/settings/DebugSettingsPanel.tsx`
- `src/components/settings/EditorSettingsPanel.tsx`
- `src/components/settings/FilesSettingsPanel.tsx`
- `src/components/settings/GitSettingsPanel.tsx`
- `src/components/settings/NetworkSettingsPanel.tsx`
- `src/components/settings/TerminalSettingsPanel.tsx`
- `src/components/settings/WorkbenchSettingsPanel.tsx`