### PR TITLE
fix: make AI thread list resizable and remove hardcoded width (#24620)

### DIFF
--- a/src/components/ai/ThreadList.tsx
+++ b/src/components/ai/ThreadList.tsx
@@ -324,7 +324,7 @@ export function ThreadList(props: ThreadListProps) {
       style={{
         display: "flex",
         "flex-direction": "column",
-        width: "240px",
+        width: "clamp(200px, 20vw, 500px)", resize: "horizontal", overflow: "auto",
         height: "100%",
         background: "var(--background-stronger)",
         "border-right": "1px solid var(--border-weak)",


### PR DESCRIPTION
Fixes #24620. Replaced the hardcoded 240px width with a resizable CSS clamp and added 'resize: horizontal' to allow manual adjustment of the thread list width.