### PR TITLE
chore(gitignore): ignore tsbuildinfo cache artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,6 @@ src-tauri/WixTools/
 # Build cache
 .cargo/
 .sccache/
+*.tsbuildinfo
 # Coverage output
 coverage/


### PR DESCRIPTION
$## Summary\n- ignore generated `*.tsbuildinfo` files in the root `.gitignore`\n- keep TypeScript incremental build cache artifacts out of `git status`\n\n## Changes\n- added a root ignore rule for TypeScript build info cache files