### PR TITLE
docs(audit): add consolidated synthesis report

### DIFF
--- a/audit-synthesis-report.md
+++ b/audit-synthesis-report.md
@@ -1,0 +1,573 @@
+# Consolidated Audit Synthesis Report — Cortex IDE
+
+## Executive Summary
+
+Across the available audit streams, the most urgent issues are runtime and product-behavior failures rather than compiler correctness. The single highest-impact frontend defect is the welcome-route layout regression that collapses the main IDE workspace to `0px` height, effectively hiding the sidebar, editor, chat, and terminal. The single highest-risk backend cluster is the set of IPC failures where commands either panic or perform their side effects but never resolve back to the frontend.
+
+A second tier of issues includes dependency vulnerabilities in the Node/Tauri toolchain, accessibility regressions caused by dynamically injected styles not being applied in WebKitGTK, and backend robustness gaps such as incomplete `batch_invoke` coverage, lack of partial settings updates, and overly restrictive path validation for workspace symbol search. The Rust backend itself appears structurally healthy, but fresh Linux environments are blocked by missing GUI/system build prerequisites.
+
+### Top conclusions
+
+1. **Fix the welcome-route layout bug first** because it makes the product visually unusable.
+2. **Stabilize IPC completion semantics next** because filesystem, git, terminal, and startup workflows cannot be trusted when commands hang or panic.
+3. **Restore reliable runtime CSS application** so accessibility and layout behavior are not platform-dependent.
+4. **Patch dependency advisories** after the product-stability issues above are addressed.
+
+---
+
+## Audit Inputs
+
+This synthesis combines the following repository artifacts:
+
+- `TYPESCRIPT_AUDIT.md`
+- `error-catalog.md`
+- `rust-compilation-audit.md`
+- `bug-report-ipc-command.md`
+- `bug-report-dom-visual-smoke.md`
+- `bug-report.md`
+- `lint-errors.txt`
+- `PROJECT_STRUCTURE.md`
+- `README.md`
+- `AGENTS.md`
+
+It also cross-checks the highest-priority claims against source code in:
+
+- `src/components/cortex/CortexDesktopLayout.tsx`
+- `src/pages/Welcome.tsx`
+- `src/context/AccessibilityContext.tsx`
+- `src-tauri/src/fs/security.rs`
+- `src-tauri/src/batch_ipc.rs`
+- `src-tauri/src/settings/commands.rs`
+- `src-tauri/src/terminal/process.rs`
+- `src-tauri/src/git/clone.rs`
+- `src-tauri/src/git/status.rs`
+- `src-tauri/src/git/staging.rs`
+- `src-tauri/src/keybindings.rs`
+- `src-tauri/src/editor/symbols.rs`
+
+---
+
+## Methodology
+
+Each finding was normalized across four ranking dimensions:
+
+- **Severity**: how badly the issue affects correctness, safety, or serviceability
+- **User impact**: how much of the user experience or workflow is degraded
+- **Exploitability / triggerability**: how easy it is to trigger in normal operation or abuse in practice
+- **Remediation effort**: relative engineering cost and implementation risk
+
+### Normalization rules
+
+- Runtime regressions that make the product unusable outrank code-health debt.
+- Verified source-backed findings outrank inference-only findings.
+- Environment-only issues are called out separately from product defects.
+- “Exploitability” is interpreted broadly here as either security exploitability or practical triggerability, depending on the issue class.
+
+### Verification caveat
+
+The audit artifacts were generated in a more provisioned environment than the current shell. Current live verification shows:
+
+- `npm run typecheck` currently fails because frontend dependencies are not installed in this shell.
+- `npm run build` currently fails because `vite` is not installed in this shell.
+- `cargo check` currently fails because Linux GUI prerequisites such as `glib-2.0` are missing.
+
+This means some older “green” audit results remain useful evidence, but only when interpreted alongside the current environment state.
+
+---
+
+## Ranked Findings
+
+| Rank | Finding | Severity | User Impact | Exploitability / Triggerability | Remediation Effort | Primary Sources |
+|---|---|---|---|---|---|---|
+| 1 | Welcome route collapses the main IDE workspace | Critical | Critical | High | Low-Medium | `bug-report-dom-visual-smoke.md`, `src/components/cortex/CortexDesktopLayout.tsx`, `src/pages/Welcome.tsx` |
+| 2 | IPC commands panic or never resolve | Critical | Critical | High | Medium-High | `bug-report-ipc-command.md`, Rust command implementations |
+| 3 | Dynamic style tags are not applied in WebKitGTK | High | High | High | Medium | `bug-report-dom-visual-smoke.md`, `src/context/AccessibilityContext.tsx` |
+| 4 | Root app and MCP server contain known dependency vulnerabilities | High | Medium-High | Medium | Low-Medium | `TYPESCRIPT_AUDIT.md` |
+| 5 | Skip-link becomes visibly rendered and shifts layout | High | Medium | High | Low | `bug-report-dom-visual-smoke.md`, `src/context/AccessibilityContext.tsx` |
+| 6 | `batch_invoke` only supports a narrow subset of commands | Medium | Medium | High | Medium | `bug-report-ipc-command.md`, `src-tauri/src/batch_ipc.rs` |
+| 7 | `settings_update` rejects partial updates | Medium | Medium | High | Medium | `bug-report-ipc-command.md`, `src-tauri/src/settings/commands.rs` |
+| 8 | `get_workspace_symbols` rejects valid nonstandard workspace paths | Medium | Medium | High | Low | `bug-report-ipc-command.md`, `src-tauri/src/fs/security.rs`, `src-tauri/src/editor/symbols.rs` |
+| 9 | `list_listening_ports` hard-depends on `lsof` | Medium | Medium | High | Low-Medium | `bug-report-ipc-command.md`, `src-tauri/src/terminal/process.rs` |
+| 10 | Type-safety debt is large despite current-config green builds | Medium | Medium | Medium | High | `error-catalog.md` |
+| 11 | Vite build warnings indicate semantic/runtime issues | Low-Medium | Medium | Medium | Low-Medium | `TYPESCRIPT_AUDIT.md` |
+| 12 | Rust/Linux builds are blocked by missing system prerequisites | Medium (developer-facing) | Medium (developer-facing) | High | Low operational effort | `rust-compilation-audit.md` |
+
+---
+
+## Detailed Findings
+
+### 1. Welcome route collapses the main IDE workspace
+
+- **Severity:** Critical
+- **User impact:** Critical
+- **Exploitability / triggerability:** Very high
+- **Remediation effort:** Low-Medium
+
+#### Why this matters
+This issue makes the IDE effectively unusable on the welcome route: the shell chrome appears, but the actual workspace collapses.
+
+#### Evidence
+- `bug-report-dom-visual-smoke.md` reports `BUG-001` with `main` at `0px` height and the welcome page consuming the flex container.
+- `src/components/cortex/CortexDesktopLayout.tsx:448-556` renders `<main>` and later renders `{props.children}` outside `<main>`.
+- `src/pages/Welcome.tsx:68-81` gives the welcome root `height: "100%"`, allowing it to consume available flex height as a sibling.
+
+#### Root cause
+The routed page content is rendered as a sibling of `<main>` instead of a child. That breaks flex layout assumptions and lets the welcome page steal height from the workspace.
+
+#### Recommended remediation
+Render the routed content inside `<main>` or convert the welcome view into an overlay that does not participate in the shell flex layout.
+
+---
+
+### 2. IPC commands panic or never resolve
+
+- **Severity:** Critical
+- **User impact:** Critical
+- **Exploitability / triggerability:** High
+- **Remediation effort:** Medium-High
+
+#### Why this matters
+Core workflows cannot be trusted when commands crash tasks or leave the UI waiting indefinitely. The most serious cases affect filesystem mutation, terminal startup, git, and app initialization.
+
+#### Evidence
+`bug-report-ipc-command.md` reports:
+
+- panic cluster affecting:
+  - `git_init`
+  - `git_commit`
+  - `git_clone`
+  - `git_unstage`
+  - `load_keybindings_file`
+- timeout / non-resolving cluster affecting:
+  - `fs_create_file`
+  - `fs_write_file`
+  - `fs_create_directory`
+  - `fs_delete_directory`
+  - `write_file`
+  - `delete_entry`
+  - `terminal_create`
+  - `settings_reset`
+  - `frontend_ready`
+  - `get_system_specs`
+  - `list_available_themes`
+  - `debug_detect_adapters`
+  - `notebook_*`
+  - `cortex_create_session`
+  - others
+
+Source corroboration shows the affected areas are implemented in the expected locations:
+
+- `src-tauri/src/git/status.rs:28-53`
+- `src-tauri/src/git/staging.rs:138-208`
+- `src-tauri/src/git/clone.rs:38-162`
+- `src-tauri/src/keybindings.rs:80-106`
+- `src-tauri/src/fs/operations.rs:175-202, 281-307`
+- `src-tauri/src/fs/directory.rs:28-49, 52-89`
+- `src-tauri/src/fs_commands.rs:145-177`
+
+#### Synthesis
+The most important detail is that some FS commands reportedly **do perform their side effects** but never resolve their Promise. That strongly suggests completion-path issues such as watcher/event deadlocks, lock contention, or blocked response delivery rather than raw logic failure.
+
+#### Recommended remediation
+Treat this as a backend stabilization project:
+
+1. instrument command entry, side-effect completion, event emission, and response return
+2. isolate file watcher side effects from command completion
+3. add timeout guards around long-running startup and discovery flows
+4. harden all process-spawning paths against panic-inducing I/O behavior
+
+---
+
+### 3. Dynamic style tags are not applied in WebKitGTK
+
+- **Severity:** High
+- **User impact:** High
+- **Exploitability / triggerability:** High in the affected runtime
+- **Remediation effort:** Medium
+
+#### Why this matters
+This issue breaks more than aesthetics. It affects accessibility, motion reduction, theming transitions, and terminal rendering.
+
+#### Evidence
+- `bug-report-dom-visual-smoke.md` reports that multiple dynamically injected style tags have `.sheet === null` and are not applied.
+- `src/context/AccessibilityContext.tsx:352-356` injects `#accessibility-styles` dynamically.
+- `src/context/AccessibilityContext.tsx:423-443` defines `.skip-link` styles inside that injected block.
+- `src/context/AccessibilityContext.tsx:698-703` renders the `.skip-link` anchor.
+
+#### Root cause
+Most likely a runtime CSP or WebKitGTK behavior mismatch around dynamically created `<style>` tags, especially where nonce behavior differs from the working style element.
+
+#### Recommended remediation
+Either:
+
+- move critical runtime CSS into the compiled bundle, or
+- propagate a valid CSP nonce to every runtime-injected style tag
+
+Bundling the styles is the more durable fix.
+
+---
+
+### 4. Dependency vulnerabilities in the root app and MCP server
+
+- **Severity:** High
+- **User impact:** Medium-High
+- **Exploitability / triggerability:** Medium
+- **Remediation effort:** Low-Medium
+
+#### Evidence
+`TYPESCRIPT_AUDIT.md` reports the following advisories.
+
+Root project:
+- `minimatch` — ReDoS via wildcards/extglobs
+- `rollup` — arbitrary file write via path traversal
+- `tar` — arbitrary file read/write via hardlink escape
+- transitive vulnerable `npm`
+
+MCP server:
+- `hono` — auth bypass advisory
+- `minimatch` — ReDoS
+- `ajv` — moderate ReDoS
+
+#### Recommended remediation
+Run targeted dependency upgrades for both `/workspace/ide` and `/workspace/ide/mcp-server`, then verify build and runtime compatibility rather than blindly applying lockfile churn.
+
+---
+
+### 5. Skip-link becomes visibly rendered and shifts layout
+
+- **Severity:** High
+- **User impact:** Medium
+- **Exploitability / triggerability:** High in the affected runtime
+- **Remediation effort:** Low
+
+#### Evidence
+- `bug-report-dom-visual-smoke.md` reports `BUG-002` showing the skip-link consumes `18px` at the top of the viewport.
+- `src/context/AccessibilityContext.tsx:423-443` relies on injected `.skip-link` CSS to hide the anchor off-screen.
+- `src/context/AccessibilityContext.tsx:699-701` renders the anchor element.
+
+#### Root cause
+The underlying problem is probably the style-injection failure rather than the skip-link implementation itself.
+
+#### Recommended remediation
+Add inline/fallback positioning styles for the skip-link and fix the dynamic-style reliability problem.
+
+---
+
+### 6. `batch_invoke` only supports a narrow subset of commands
+
+- **Severity:** Medium
+- **User impact:** Medium
+- **Exploitability / triggerability:** High
+- **Remediation effort:** Medium
+
+#### Evidence
+- `bug-report-ipc-command.md` reports that `batch_invoke` rejects valid registered commands like `get_server_info`.
+- `src-tauri/src/batch_ipc.rs:65-77` confirms a hard-coded dispatcher that only handles a small fixed set.
+- `src-tauri/src/batch_ipc.rs:171-186` shows the batching mechanism itself is generic, but dispatch coverage is not.
+
+#### Recommended remediation
+Either expand dispatch coverage substantially or constrain the contract explicitly so callers do not assume all Tauri commands are batchable.
+
+---
+
+### 7. `settings_update` rejects partial updates
+
+- **Severity:** Medium
+- **User impact:** Medium
+- **Exploitability / triggerability:** High
+- **Remediation effort:** Medium
+
+#### Evidence
+- `bug-report-ipc-command.md` reports that updating only `{ fontSize: 16 }` fails because the whole editor section is expected.
+- `src-tauri/src/settings/commands.rs:98-210` confirms each section is replaced through `serde_json::from_value(value)` on the full section type.
+
+#### Recommended remediation
+Merge partial payloads into the existing section before validation and persistence.
+
+---
+
+### 8. `get_workspace_symbols` rejects valid nonstandard workspace paths
+
+- **Severity:** Medium
+- **User impact:** Medium
+- **Exploitability / triggerability:** High in containers/CI/custom mounts
+- **Remediation effort:** Low
+
+#### Evidence
+- `bug-report-ipc-command.md` reports `/workspace/ide` being rejected.
+- `src-tauri/src/editor/symbols.rs:262-280` validates `workspace_path` via `validate_path_for_read`.
+- `src-tauri/src/fs/security.rs:14-82` shows `get_allowed_roots()` includes `cwd` only on Windows, not Unix.
+- `src-tauri/src/fs/security.rs:153-168` enforces allowed-root membership.
+
+#### Recommended remediation
+Include the current working directory on Unix as well, or better, derive allowed roots from explicitly opened workspace roots rather than a static heuristic.
+
+---
+
+### 9. `list_listening_ports` hard-depends on `lsof`
+
+- **Severity:** Medium
+- **User impact:** Medium
+- **Exploitability / triggerability:** High
+- **Remediation effort:** Low-Medium
+
+#### Evidence
+- `bug-report-ipc-command.md` reports failure when `lsof` is absent.
+- `src-tauri/src/terminal/process.rs:382-393` confirms `list_listening_ports_impl()` shells out directly to `lsof` with no fallback.
+- `src-tauri/src/terminal/process.rs:263-271` shows the same pattern for per-port process lookup.
+
+#### Recommended remediation
+On Linux, fall back to `/proc/net/tcp` and `/proc/net/tcp6` parsing when `lsof` is unavailable.
+
+---
+
+### 10. Type-safety debt is large despite green current-config builds
+
+- **Severity:** Medium
+- **User impact:** Medium
+- **Exploitability / triggerability:** Medium
+- **Remediation effort:** High overall
+
+#### Evidence
+`error-catalog.md` reports:
+
+- 935 `: any` annotations
+- 528 `as any` casts
+- 29 suppressions (`@ts-ignore`, `@ts-expect-error`)
+- ~3,981 issues surfacing under `noUncheckedIndexedAccess`
+- a hidden `vite-env.d.ts` declaration conflict when `skipLibCheck` is disabled
+
+#### Synthesis
+This is genuine reliability debt, but it should not outrank product-breaking layout and IPC issues. The best use of effort is targeted reduction in foundational hotspots rather than a broad cleanup campaign.
+
+#### Best early wins
+- fix `src/vite-env.d.ts`
+- add `requestIdleCallback` typing
+- type `src/utils/decorators.ts`
+- reduce debugger protocol `any` usage in high-touch code paths
+
+---
+
+### 11. Vite build warnings indicate semantic/runtime issues
+
+- **Severity:** Low-Medium
+- **User impact:** Medium
+- **Exploitability / triggerability:** Medium
+- **Remediation effort:** Low-Medium
+
+#### Evidence
+`TYPESCRIPT_AUDIT.md` reports:
+- browser-bundle warnings from direct `fs` / `path` imports in `src/utils/terminalLinks.ts`
+- malformed HTML caused by nested `<button>` elements
+- expected large Monaco worker chunks
+
+#### Synthesis
+The malformed HTML warning is the most actionable item here because it overlaps with accessibility and DOM correctness concerns.
+
+---
+
+### 12. Rust/Linux build prerequisites block fresh environments
+
+- **Severity:** Medium for contributors and CI
+- **User impact:** Medium for onboarding/build automation
+- **Exploitability / triggerability:** High on fresh Linux systems
+- **Remediation effort:** Low operational effort
+
+#### Evidence
+`rust-compilation-audit.md` reports missing:
+- `../dist`
+- GTK/WebKit/GLib development libraries
+- `libxdo`
+
+Current `cargo check` in this shell independently confirms missing `glib-2.0`, `gobject-2.0`, and `gio-2.0`.
+
+#### Synthesis
+This is not a product defect, but it is a real delivery and onboarding problem.
+
+---
+
+## Evidence Summary by Source
+
+### `bug-report-dom-visual-smoke.md`
+Primary value:
+- strongest evidence for the layout regression
+- strongest evidence for dynamic-style failures and accessibility fallout
+- strongest evidence for visible user impact
+
+### `bug-report-ipc-command.md`
+Primary value:
+- strongest evidence for backend command panic/hang clusters
+- strongest evidence for medium-severity API contract gaps
+- clearest remediation ideas for backend stabilization
+
+### `TYPESCRIPT_AUDIT.md`
+Primary value:
+- dependency vulnerability inventory
+- build-warning inventory
+- reference point showing the project can be healthy in a properly provisioned environment
+
+### `error-catalog.md`
+Primary value:
+- realistic map of latent type debt
+- hidden config issues not visible under the default TS settings
+- priority-ordered code-health recommendations
+
+### `rust-compilation-audit.md`
+Primary value:
+- confirms Rust code quality is generally strong
+- isolates environment prerequisites from actual backend code defects
+
+### `PROJECT_STRUCTURE.md`
+Primary value:
+- warns that baseline verification can drift due to concurrent commits and environment differences
+- identifies prior pre-existing failures that should not be conflated with this synthesis
+
+---
+
+## Recommended Roadmap
+
+### Phase 0 — Immediate critical fixes
+
+1. **Fix welcome/main layout architecture**
+2. **Fix non-resolving IPC commands**
+3. **Fix git/keybindings panic paths**
+4. **Restore dynamic CSS reliability in WebKitGTK**
+
+These should be treated as product-stability blockers.
+
+### Phase 1 — Security and backend robustness
+
+5. **Patch dependency vulnerabilities** in both the root app and MCP server
+6. **Support nonstandard workspace roots** for symbol search and related file APIs
+7. **Add `lsof` fallback behavior** on Linux
+8. **Support partial settings updates**
+9. **Clarify or expand `batch_invoke` coverage**
+
+### Phase 2 — Accessibility and semantic correctness
+
+10. Fix unlabeled buttons and icon-only controls
+11. Add missing ARIA landmarks for navigation/sidebar/footer/search
+12. Fix malformed nested-button markup if still present after layout corrections
+
+### Phase 3 — Quality-debt reduction
+
+13. Fix `vite-env.d.ts`
+14. Add missing low-risk global typings (`requestIdleCallback`, etc.)
+15. Tackle foundational `any` hotspots such as decorators/debugger utilities
+16. Consider lint adoption and stricter TS flags after runtime stability work is complete
+
+---
+
+## Explicit Critical-Fix Candidates for Implementation
+
+### Candidate A — Welcome layout unblocker
+
+**Target files**
+- `src/components/cortex/CortexDesktopLayout.tsx`
+- potentially `src/pages/Welcome.tsx`
+
+**Scope**
+- move routed children into `<main>` or make the welcome surface non-layout-participating
+- verify `/welcome` with no project loaded
+- verify sidebar/editor/chat/terminal remain visible and sized correctly
+
+**Why this is first**
+It is likely a low-effort, high-confidence fix for the most user-visible product failure.
+
+---
+
+### Candidate B — IPC completion reliability pass
+
+**Target files / areas**
+- `src-tauri/src/fs/operations.rs`
+- `src-tauri/src/fs/directory.rs`
+- `src-tauri/src/fs_commands.rs`
+- terminal/session initialization flows
+
+**Scope**
+- instrument command lifecycle boundaries
+- verify mutation commands always resolve or fail explicitly
+- isolate file watcher emissions from command completion paths
+- add timeout/fail-fast guards to long-running calls
+
+**Why this is first-tier**
+It affects correctness of core IDE operations even when side effects appear to succeed.
+
+---
+
+### Candidate C — Git/keybindings panic hardening
+
+**Target files**
+- `src-tauri/src/git/status.rs`
+- `src-tauri/src/git/staging.rs`
+- `src-tauri/src/git/clone.rs`
+- `src-tauri/src/keybindings.rs`
+- shared process utility wrappers as needed
+
+**Scope**
+- harden process I/O behavior and panic handling
+- ensure stderr/stdout handling cannot crash async tasks under headless or detached conditions
+- add targeted regression tests where possible
+
+**Why this is first-tier**
+Crashes destroy operator trust faster than ordinary command failures.
+
+---
+
+### Candidate D — Runtime CSS/CSP stabilization
+
+**Target files**
+- `src/context/AccessibilityContext.tsx`
+- any other runtime style injectors
+
+**Scope**
+- move critical rules into bundled CSS or propagate CSP nonce consistently
+- add skip-link fallback styles so accessibility behavior remains safe even if injection fails
+
+**Why this is first-tier**
+It resolves both accessibility regressions and platform-specific layout artifacts.
+
+---
+
+### Candidate E — Dependency security sweep
+
+**Target files**
+- `package.json`
+- `package-lock.json`
+- `mcp-server/package.json`
+- `mcp-server/package-lock.json`
+
+**Scope**
+- remediate known advisories
+- verify build/test/runtime compatibility after upgrades
+
+**Why this is next**
+This is the clearest conventional security work item and relatively straightforward once product stability is restored.
+
+---
+
+## Implementation Order Recommendation
+
+If only one focused engineering sprint is available, the recommended order is:
+
+1. Candidate A — welcome layout fix
+2. Candidate B — IPC completion reliability pass
+3. Candidate C — git/keybindings panic hardening
+4. Candidate D — CSS/CSP stabilization
+5. Candidate E — dependency remediation
+
+This sequence maximizes immediate user-visible recovery while reducing the risk of masking runtime defects behind code-health or tooling work.
+
+---
+
+## Final Assessment
+
+The audit streams converge on one clear story: **Cortex IDE’s main near-term risk is runtime reliability, not static typing or Rust compilation quality**. The product is currently most threatened by a shell-layout regression that can hide the workspace and by backend IPC behaviors that hang or crash critical workflows. Security and quality debt are real, but they should be sequenced behind the fixes that restore usability and command reliability.
+
+The most implementation-ready critical-fix candidates are therefore:
+
+1. **Welcome layout repair**
+2. **IPC completion stabilization**
+3. **Git/keybindings panic hardening**
+4. **Dynamic style/CSP repair**
+5. **Dependency vulnerability remediation**


### PR DESCRIPTION
## Summary
- add a consolidated audit synthesis report at the repo root
- rank findings by severity, user impact, exploitability, and remediation effort
- include an executive summary, methodology, evidence, roadmap, and critical-fix candidates

## Evidence synthesized
- TypeScript audit
- error catalog
- Rust compilation audit
- IPC command bug report
- DOM/visual smoke bug report
- lint report
- project structure baseline