### PR TITLE
docs(audit): add consolidated audit synthesis report

### DIFF
--- a/audit-synthesis-report.md
+++ b/audit-synthesis-report.md
@@ -1,7 +1,7 @@
 # Cortex IDE — Comprehensive Audit Synthesis Report
 
-**Synthesis date:** 2026-03-10  
-**Repository:** `/workspace/ide`  
+**Synthesis date:** 2026-03-10<br>
+**Repository:** `CortexLM/cortex-ide`<br>
 **Purpose:** Reconcile the repository’s architecture, runtime, build, and code-quality audit streams into one actionable engineering report.
 
 ---
@@ -344,7 +344,7 @@ This specific failure mode appears to be **addressed by subsequent code changes*
 - `src-tauri/src/git/command.rs`: shell-based git helpers capture stdout/stderr explicitly via piped handles.
 - `src-tauri/src/git/clone.rs`: clone progress reads piped stderr inside a dedicated thread wrapped with `catch_unwind`.
 - `src-tauri/src/keybindings.rs`: `load_keybindings_file` now reads/parses a JSON file and does not invoke an external process.
-- `src-tauri/src/git/staging.rs`: unsiged `git_commit` uses libgit2 directly; the CLI path is limited to signed commits and also captures stderr.
+- `src-tauri/src/git/staging.rs`: unsigned `git_commit` operations use libgit2 directly; the CLI path is limited to signed commits and also captures stderr.
 
 **Status**  
 **Marked as addressed in code, but still requires runtime regression verification** once the Tauri environment is buildable again.

--- a/audit-synthesis-report.md
+++ b/audit-synthesis-report.md
@@ -1,0 +1,438 @@
+# Cortex IDE — Comprehensive Audit Synthesis Report
+
+**Synthesis date:** 2026-03-10  
+**Repository:** `/workspace/ide`  
+**Purpose:** Reconcile the repository’s architecture, runtime, build, and code-quality audit streams into one actionable engineering report.
+
+---
+
+## Executive Summary
+
+Cortex IDE is a three-surface system: a large SolidJS/TypeScript frontend, a Tauri v2 Rust backend with a broad IPC surface, and a separate MCP server that exposes desktop capabilities to external agents. Across the audit streams, the strongest open product risk is a **frontend shell composition bug on `/welcome`** that can collapse the main IDE workspace to `0px` height, effectively hiding the core editor experience. The strongest open platform risk is a **cluster of IPC commands that reportedly hang or never resolve**, affecting filesystem, terminal, startup, AI, notebook, and debug flows.
+
+The audit set also shows substantial but lower-priority engineering debt: accessibility regressions in WebKitGTK, fragile cross-platform/system-integration behavior, missing lint governance, inconsistent TypeScript strictness around `any`/suppression usage, and backend dependency/build-prerequisite friction. At the same time, not every severe historical finding still appears open: the earlier **git/keybindings broken-pipe panic** described in the IPC audit appears to be **addressed in current backend code**, although runtime regression verification is still needed once the local Tauri build environment is healthy.
+
+**Recommended near-term priority order:**
+1. Fix the `/welcome` layout regression in the frontend shell.
+2. Reproduce and eliminate the IPC timeout cluster with command-by-command regression tests.
+3. Harden accessibility fallbacks and semantic landmarks in the shell.
+4. Restore reproducible verification by standardizing JS dependencies and Linux/Tauri system prerequisites.
+5. Start a structured type-safety and linting debt reduction program.
+
+---
+
+## Audit Streams Reviewed
+
+| Source | Primary scope | Notable signals | How it was used in this synthesis |
+|---|---|---|---|
+| `README.md` | Product status and roadmap | Early alpha, rapid iteration, no prebuilt binaries | Product maturity and delivery context |
+| `AGENTS.md` + `PROJECT_STRUCTURE.md` | Architecture and build/test topology | Frontend + Tauri backend + MCP server | Architecture overview and subsystem mapping |
+| `TYPESCRIPT_AUDIT.md` | TypeScript compilation snapshot | 0 compile errors in that snapshot; build warnings only | Positive baseline for TS health when dependencies are present |
+| `error-catalog.md` | Type-safety/configuration debt | 1,491 `any`/suppression concerns, no linter, stricter flags disabled | Technical-debt prioritization |
+| `rust-compilation-audit.md` | Rust compilation, dependencies, build prerequisites | Clean code-level compile in audit snapshot, but Linux prerequisites missing | Backend build and dependency risk |
+| `bug-report-dom-visual-smoke.md` | Runtime DOM/accessibility audit on `/welcome` | Critical shell collapse, high accessibility/style issues | Frontend runtime risk assessment |
+| `bug-report-ipc-command.md` | Runtime IPC audit across ~150 commands | Panics, timeouts, partial command support, environment brittleness | Backend runtime risk assessment |
+| Current source spot-checks | Present code state | Confirmed some findings remain open; confirmed some older issues are likely superseded by code changes | Tie-breaker when audit streams conflict |
+| Current environment checks | What can be verified now | JS deps absent; Rust build blocked by missing GTK/glib packages | Verification limits and confidence calibration |
+
+---
+
+## Architecture Overview
+
+### 1. Frontend
+
+The frontend is a large SolidJS + TypeScript application under `src/` with:
+- hundreds of feature components,
+- a dense context/provider layer,
+- route pages such as `Home`, `Welcome`, `Session`, `Admin`, and `Share`,
+- editor, terminal, Git, debug, AI, and layout subsystems,
+- a browser-side IPC client in `src/sdk/`.
+
+The key shell path relevant to this report is:
+- `src/index.tsx` → router wiring,
+- `src/AppShell.tsx` / `src/AppCore.tsx` → app bootstrap,
+- `src/components/cortex/CortexDesktopLayout.tsx` → top-level IDE shell,
+- `src/pages/Welcome.tsx` → routed welcome overlay/content,
+- `src/context/AccessibilityContext.tsx` → skip-link and accessibility style injection.
+
+### 2. Backend
+
+The Tauri backend under `src-tauri/src/` is a large Rust monolith exposing nearly 1,000 IPC commands across domains including:
+- filesystem,
+- terminal/PTY,
+- Git,
+- settings,
+- editor/symbol indexing,
+- AI session orchestration,
+- notebook/debug tooling,
+- system integration and platform utilities.
+
+Subsystems most relevant to this synthesis include:
+- `src-tauri/src/batch_ipc.rs`
+- `src-tauri/src/settings/commands.rs`
+- `src-tauri/src/editor/symbols.rs`
+- `src-tauri/src/terminal/commands.rs`
+- `src-tauri/src/terminal/process.rs`
+- `src-tauri/src/app/mod.rs`
+- `src-tauri/src/fs/directory.rs`
+- `src-tauri/src/git/*.rs`
+- `src-tauri/src/keybindings.rs`
+
+### 3. MCP Server
+
+The separate `mcp-server/` package is a Node/TypeScript stdio server that exposes Cortex Desktop capabilities to external agents. It is architecturally important because it amplifies the cost of IPC contract instability: backend hangs or incomplete command support become external tool failures, not just UI bugs.
+
+---
+
+## Methodology
+
+### Reconciliation rules
+
+The audit streams were produced on different dates, branches, and environments, and they do not fully agree. This synthesis used the following precedence order:
+
+1. **Current source inspection** of relevant frontend/backend files.
+2. **Runtime bug reports** for behavior that depends on Tauri/WebKitGTK or IPC execution.
+3. **Compilation/build audits** for broader toolchain and technical-debt patterns.
+4. **Project documentation** for architecture and intended workflows.
+
+### Current-source spot checks performed
+
+The following files were inspected to reconcile open vs. closed findings:
+- `src/components/cortex/CortexDesktopLayout.tsx`
+- `src/pages/Welcome.tsx`
+- `src/context/AccessibilityContext.tsx`
+- `src/vite-env.d.ts`
+- `src-tauri/src/git/status.rs`
+- `src-tauri/src/git/staging.rs`
+- `src-tauri/src/git/command.rs`
+- `src-tauri/src/git/clone.rs`
+- `src-tauri/src/keybindings.rs`
+- `src-tauri/src/batch_ipc.rs`
+- `src-tauri/src/settings/commands.rs`
+- `src-tauri/src/editor/symbols.rs`
+- `src-tauri/src/terminal/process.rs`
+- `src-tauri/src/app/mod.rs`
+- `src-tauri/src/fs/directory.rs`
+
+### Current verification checks
+
+The following environment checks were run during synthesis:
+- `test -d node_modules` and `test -d mcp-server/node_modules`
+- `npm run typecheck`
+- `cargo check` in `src-tauri/`
+
+### Verification limitations
+
+Current direct verification is constrained by the local environment:
+- `node_modules` is currently absent at both the root and `mcp-server/`, so frontend TypeScript verification currently fails with missing-module errors rather than source-level correctness signals.
+- `cargo check` currently fails before application code is analyzed because Linux system packages such as `gio-2.0`, `glib-2.0`, and `gobject-2.0` are unavailable in this environment.
+
+These limitations do **not** invalidate the audit synthesis; they do reduce confidence in runtime re-verification until the workspace is rehydrated.
+
+---
+
+## Severity Rationale
+
+| Severity | Definition used in this report |
+|---|---|
+| **Critical** | Breaks core IDE usability or causes common workflows to panic/hang without a reliable recovery path |
+| **High** | Severely degrades accessibility, platform operability, or fresh-build success, but does not fully brick the product |
+| **Medium** | Breaks specific workflows, weakens portability/correctness, or increases incident risk without full outage |
+| **Low** | Maintainability, hygiene, or efficiency debt with limited immediate user impact |
+
+---
+
+## Prioritized Findings
+
+| Priority | Finding | Severity | Status | Primary affected areas |
+|---|---|---|---|---|
+| 1 | `/welcome` route can collapse the main IDE shell to `0px` height | **Critical** | **Open** | Frontend shell, layout composition, first-run UX |
+| 2 | Large IPC timeout / never-resolve cluster across backend commands | **Critical** | **Open / needs targeted revalidation** | Filesystem, terminal, startup, AI, notebook, debug, settings |
+| 3 | Accessibility/style fallback regressions in shell rendering | **High** | **Open** | Skip-link, style injection, title bar controls, landmarks |
+| 4 | Fresh-build and verification fragility in local/Linux environments | **High** | **Open** | Backend contributor onboarding, CI parity, local validation |
+| 5 | Type-safety and quality-governance debt is broad and under-instrumented | **Medium** | **Open** | Frontend correctness, maintainability, review burden |
+| 6 | IPC contract gaps and cross-platform assumptions remain brittle | **Medium** | **Open** | Batch IPC, settings API, symbol search, port inspection, browser/file helpers |
+| 7 | Dependency hygiene, dead code, and formatting drift increase drag | **Low** | **Open** | Rust dependency tree, build time, repository cleanliness |
+
+### 1) `/welcome` route collapses the main IDE workspace
+
+**Why this is critical**  
+The DOM/visual smoke audit reports that the core IDE workspace becomes invisible because `<main>` is squeezed to `0px` height. That is a first-order product failure: the editor, sidebar, chat, and terminal become effectively unusable.
+
+**Current-source evidence**
+- `src/components/cortex/CortexDesktopLayout.tsx` still renders `{props.children}` **outside** the `<main>` container.
+- `src/pages/Welcome.tsx` still renders the welcome wrapper at `width: 100%` and `height: 100%`.
+- This matches the audit’s explanation that routed page content participates as a sibling in the shell flex layout rather than as content inside the main region.
+
+**Affected areas**
+- `src/components/cortex/CortexDesktopLayout.tsx`
+- `src/pages/Welcome.tsx`
+- Sidebar, editor, chat panel, terminal, and any route using the shell composition pattern
+
+**Remediation guidance**
+- Move routed content (`{props.children}`) inside `<main>`, or
+- convert the welcome experience into an absolutely positioned overlay that does not consume flex space, and
+- add a regression test that asserts the main shell remains visible when the welcome route is active.
+
+### 2) IPC timeout / never-resolve cluster across backend commands
+
+**Why this is critical**  
+The IPC audit reports ~15 commands timing out and several file operations completing their side effects on disk while the Promise never resolves. That is a reliability problem at the contract boundary between UI/agent tooling and the backend.
+
+**Representative affected commands from the audit**
+- `fs_create_file`, `fs_write_file`, `fs_create_directory`, `fs_delete_directory`
+- `terminal_create`
+- `settings_reset`
+- `frontend_ready`
+- `get_system_specs`
+- `list_available_themes`
+- `check_for_updates`
+- `notebook_detect_kernels`, `notebook_list_kernels`
+- `debug_detect_adapters`
+- `cortex_create_session`, `ai_init_threads`
+- `git_watch_repository`, `add_recent_workspace`, `git_forge_authenticate`
+
+**Current-source assessment**
+- The backend still exposes broad async/blocking seams across filesystem, terminal, system, and watcher code.
+- No repository-wide timeout or completion-contract hardening layer was found during spot checks.
+- This means the audit should still be treated as an open reliability risk until a command-by-command regression sweep proves otherwise.
+
+**Affected areas**
+- Backend IPC boundary broadly
+- Tauri command lifecycle and async completion paths
+- Agent/MCP consumers that depend on deterministic IPC responses
+
+**Remediation guidance**
+- Create a focused IPC reliability test harness that invokes high-risk commands under Tauri integration tests.
+- Start with file operations and terminal creation because they were reported to produce side effects without resolution.
+- Add explicit timeout instrumentation and structured tracing around command entry/exit for the critical commands.
+- Normalize command patterns so side effects, event emission, and response completion happen in a single observable flow.
+
+### 3) Accessibility and style fallback regressions in the shell
+
+**Why this is high severity**  
+The DOM audit shows accessibility regressions that materially degrade keyboard and assistive-tech usability: a visible skip-link consuming layout space, style tags not applying in the tested environment, missing accessible names on buttons, and missing landmarks.
+
+**Current-source evidence**
+- `src/context/AccessibilityContext.tsx` still injects `.skip-link` styles through a dynamically created `<style>` tag.
+- The rendered skip-link points to `#main-content`, but a current search did not find a matching `id="main-content"` target in `src/`.
+- The current code does not show an inline fallback style on the skip-link element.
+
+**Affected areas**
+- Accessibility bootstrap in `src/context/AccessibilityContext.tsx`
+- Shell semantics and focus navigation
+- Title bar / icon-only control surfaces
+
+**Remediation guidance**
+- Give the primary content container a real `id="main-content"` target.
+- Add inline/fallback positioning for the skip-link so it remains off-screen even if injected stylesheet rules fail.
+- Audit icon-only buttons for accessible names.
+- Add shell landmark semantics and/or explicit ARIA roles where the visual structure already implies them.
+- Re-run WebKitGTK/Tauri accessibility smoke tests after the layout fix.
+
+### 4) Fresh-build and verification fragility remains too high
+
+**Why this is high severity**  
+The Rust audit identifies missing Linux prerequisites (`glib`, GTK/WebKit, `libxdo`) as build blockers on fresh machines. Current direct verification also failed because JS dependencies are not installed in this workspace. This increases contributor friction and slows incident response because the team cannot rapidly re-run validation in a clean environment.
+
+**Current verification evidence**
+- Root `node_modules` is missing.
+- `mcp-server/node_modules` is missing.
+- `npm run typecheck` currently fails with missing package/module errors, so it cannot serve as a source-health signal until dependencies are restored.
+- `cargo check` currently fails in system dependency detection before app code is checked.
+
+**Affected areas**
+- Local onboarding
+- CI parity
+- Fast bug reproduction and audit refreshes
+
+**Remediation guidance**
+- Treat environment bootstrap as an engineering deliverable, not tribal knowledge.
+- Standardize a reproducible validation baseline for JS dependencies and Linux/Tauri system libraries.
+- Ensure CI and local docs/scripts converge on the same prerequisite set and artifact assumptions.
+
+### 5) Type-safety and governance debt is substantial
+
+**Why this is medium severity**  
+The repository compiles under its configured TypeScript settings in at least one audit snapshot, but the `error-catalog.md` audit still reports 1,491 instances of `: any`, `as any`, `@ts-ignore`, and `@ts-expect-error`, plus missing linting and stricter compiler coverage gaps. This is not an immediate outage, but it increases regression risk and review cost.
+
+**Key debt signals**
+- No configured linter (`lint-errors.txt`)
+- `skipLibCheck: true`
+- `noUncheckedIndexedAccess` not enabled
+- Extensive `any`/suppression usage concentrated in components, context, debugger, and utilities
+- Inconsistent findings across audits suggest the team lacks a single stable quality gate
+
+**Affected areas**
+- Frontend correctness and refactorability
+- Review burden for complex UI/state code
+- Long-tail bug discoverability
+
+**Remediation guidance**
+- Add lint governance first; do not start with a repository-wide type purge.
+- Prioritize shared utilities and high-churn context files before test-only code.
+- Convert `catch (err: any)` patterns to `unknown` and narrow explicitly.
+- Introduce stricter checks incrementally behind a debt burn-down plan rather than enabling every flag at once.
+
+### 6) IPC contract gaps and cross-platform assumptions remain brittle
+
+**Why this is medium severity**  
+Several issues reported in the IPC audit are still directly visible in current code and represent concrete API brittleness rather than general reliability concerns.
+
+**Current-source examples**
+- `src-tauri/src/batch_ipc.rs`: `batch_invoke` supports only a narrow allowlist of commands.
+- `src-tauri/src/settings/commands.rs`: `settings_update` still replaces whole sections instead of merging partial updates.
+- `src-tauri/src/terminal/process.rs`: Linux/macOS port listing still depends on `lsof`.
+- `src-tauri/src/app/mod.rs`: `open_in_browser` still assumes a graphical/openable environment.
+- `src-tauri/src/fs/directory.rs`: desktop/documents directory helpers still return hard errors when dirs cannot be resolved.
+- `src-tauri/src/editor/symbols.rs`: workspace symbol search still performs strict path validation that can reject otherwise expected inputs.
+
+**Affected areas**
+- External tool compatibility (including MCP consumers)
+- Headless/server-like environments
+- Partial settings UX and robustness
+- Cross-platform operability
+
+**Remediation guidance**
+- Publish and test an explicit IPC compatibility matrix.
+- Expand `batch_invoke` intentionally, or document it as a curated subset and enforce that contract in the frontend.
+- Support partial section merging in settings updates.
+- Add graceful fallbacks or explicit unsupported-environment errors for platform/system helpers.
+
+### 7) Dependency hygiene, dead code, and formatting drift add ongoing friction
+
+**Why this is low severity**  
+These issues are not currently the fastest path to user-visible failures, but they steadily increase build time, maintenance overhead, and cognitive load.
+
+**Signals from the Rust audit**
+- ~40 duplicate transitive dependency pairs
+- multiple version splits (`image`, `reqwest`, `tokio-tungstenite`, `rand`)
+- 3 undeclared source modules
+- 1 formatting drift case
+
+**Remediation guidance**
+- Bundle these into a dedicated maintenance sprint after runtime-critical work stabilizes.
+- Treat dead-code cleanup and dependency deduplication as a release-hardening stream, not as an opportunistic side quest during critical bug fixing.
+
+---
+
+## Affected Area Map
+
+| Area | Representative files / modules | Current risk summary |
+|---|---|---|
+| Frontend shell layout | `src/components/cortex/CortexDesktopLayout.tsx`, `src/pages/Welcome.tsx` | Critical welcome-route composition bug |
+| Accessibility layer | `src/context/AccessibilityContext.tsx`, shell/titlebar controls | High risk due to fallback/style/semantics gaps |
+| Backend IPC orchestration | `src-tauri/src/batch_ipc.rs`, command modules under `src-tauri/src/` | Critical/Medium risk from hangs and incomplete contracts |
+| Git and keybindings backend | `src-tauri/src/git/*.rs`, `src-tauri/src/keybindings.rs` | Historical critical panic appears mitigated in code |
+| Build/tooling quality gates | `tsconfig.json`, `src/vite-env.d.ts`, package scripts, Cargo deps | Medium/High risk from verification fragility and debt |
+| Cross-platform/system helpers | `terminal/process.rs`, `app/mod.rs`, `fs/directory.rs` | Medium risk in headless/minimal Linux or nonstandard environments |
+| MCP / external tool surface | `mcp-server/`, Tauri IPC consumers | Risk multiplies when backend contracts are unstable |
+
+---
+
+## Critical Issues Already Addressed by Code Changes
+
+### Addressed in code: historical git/keybindings broken-pipe panic path
+
+**Historical report**  
+`bug-report-ipc-command.md` classified a broken-pipe panic affecting `git_init`, `git_commit`, `git_clone`, `git_unstage`, and `load_keybindings_file` as **Critical**.
+
+**Current-code assessment**  
+This specific failure mode appears to be **addressed by subsequent code changes**:
+- `src-tauri/src/git/status.rs`: `git_init` now uses `git2::Repository::init` instead of shelling out.
+- `src-tauri/src/git/staging.rs`: `git_unstage` now uses libgit2 reset/index operations instead of a git CLI path.
+- `src-tauri/src/git/command.rs`: shell-based git helpers capture stdout/stderr explicitly via piped handles.
+- `src-tauri/src/git/clone.rs`: clone progress reads piped stderr inside a dedicated thread wrapped with `catch_unwind`.
+- `src-tauri/src/keybindings.rs`: `load_keybindings_file` now reads/parses a JSON file and does not invoke an external process.
+- `src-tauri/src/git/staging.rs`: unsiged `git_commit` uses libgit2 directly; the CLI path is limited to signed commits and also captures stderr.
+
+**Status**  
+**Marked as addressed in code, but still requires runtime regression verification** once the Tauri environment is buildable again.
+
+### Important contrast
+
+No equally strong source evidence was found that the following critical findings have already been fixed:
+- the `/welcome` shell layout collapse,
+- the broad IPC timeout / never-resolve cluster.
+
+Those should still be treated as open.
+
+---
+
+## Remediation Guidance by Priority Band
+
+### Immediate (next 1–2 iterations)
+- Fix the welcome-layout composition bug and add a regression test around shell visibility.
+- Reproduce the IPC timeout cluster with a bounded test matrix for filesystem, terminal, settings-reset, startup, and AI/session commands.
+- Add tracing/metrics around command completion so unresolved Promises can be correlated to backend lifecycle events.
+
+### Near-term hardening
+- Add skip-link fallback styling, semantic landmarks, accessible names, and a real `main-content` target.
+- Stabilize batch/settings contracts (`batch_invoke`, partial settings updates).
+- Make environment-dependent helpers fail predictably with actionable errors rather than opaque runtime failures.
+
+### Structural quality improvement
+- Introduce a lint gate and a typed debt budget.
+- Burn down `any`/suppression usage in shared utilities and context layers before leaf components.
+- Reconcile audit automation so there is one authoritative quality dashboard rather than multiple conflicting markdown snapshots.
+
+### Release-hardening / cleanup
+- Deduplicate Rust dependency splits where practical.
+- Remove dead modules and fix formatting drift.
+- Keep long-tail dependency hygiene separate from urgent runtime reliability work.
+
+---
+
+## Technical Debt Reduction Roadmap
+
+### Phase 0 — Restore trustworthy verification
+**Goal:** make the codebase easy to validate again.
+- Rehydrate JS dependencies in CI/local workflows.
+- Standardize Linux/Tauri prerequisite installation.
+- Ensure one command path exists for “frontend + backend sanity check”.
+
+### Phase 1 — Eliminate user-visible breakage
+**Goal:** remove the highest-severity runtime regressions.
+- Fix `/welcome` shell collapse.
+- Revalidate and fix the IPC timeout cluster.
+- Add focused smoke tests for shell layout and critical IPC commands.
+
+### Phase 2 — Harden accessibility and IPC contracts
+**Goal:** improve platform reliability and reduce support burden.
+- Add shell accessibility fallbacks and semantic structure.
+- Expand or explicitly scope `batch_invoke`.
+- Support partial settings merges and graceful headless/minimal-environment behavior.
+
+### Phase 3 — Raise code-quality floors
+**Goal:** reduce regression probability in high-churn code.
+- Introduce ESLint/TypeScript lint governance.
+- Target `any`/suppression hotspots in utilities, contexts, and debugger code.
+- Add stricter compiler options incrementally where payoff is highest.
+
+### Phase 4 — Simplify maintenance overhead
+**Goal:** improve build time and reduce incidental complexity.
+- Deduplicate transitive dependencies where feasible.
+- Remove dead modules.
+- Keep formatting and dependency hygiene continuously enforced.
+
+---
+
+## Verification Appendix
+
+### Current environment observations
+- Root `node_modules`: **missing**
+- `mcp-server/node_modules`: **missing**
+- `npm run typecheck`: **fails because dependencies are absent**, so the output is not a reliable source-health signal yet
+- `cargo check` in `src-tauri/`: **fails on missing Linux system packages** (`gio-2.0`, `glib-2.0`, `gobject-2.0`), which is consistent with the Rust audit’s build-prerequisite findings
+
+### Reconciled confidence statement
+
+- **High confidence:** architecture overview, the open `/welcome` layout bug, the open accessibility fallback gap, the existence of IPC/API contract brittleness, and the fact that the historical git/keybindings panic path has been substantially refactored.
+- **Medium confidence:** the exact current breadth of the IPC timeout cluster, because it needs runtime re-validation in a healthy Tauri environment.
+- **Lower confidence for absolute counts:** TypeScript/test totals and some debt counts, because the source audits were generated on different snapshots and with different dependency states.
+
+---
+
+## Bottom Line
+
+Cortex IDE’s biggest risks are not abstract technical debt—they are **shell usability** and **IPC reliability** in core workflows. Those should be treated as the top engineering priorities. Once those are under control, the team should immediately use the same momentum to improve accessibility fallbacks, rebuild verification reproducibility, and establish a durable lint/type-safety program so future audits converge instead of conflicting.


### PR DESCRIPTION
## Summary
- add a consolidated audit synthesis report covering architecture, methodology, prioritized findings, severity rationale, affected areas, remediation guidance, and a technical-debt roadmap
- reconcile the existing audit streams and explicitly mark critical issues that appear already addressed by code changes
- document current verification limits caused by missing JavaScript dependencies and Linux/Tauri build prerequisites