### PR TITLE
fix: add aria-live to chat messages

### DIFF
--- a/src/components/cortex/CortexChatPanel.tsx
+++ b/src/components/cortex/CortexChatPanel.tsx
@@ -212,9 +212,11 @@ const ExpandedChat: Component<Omit<CortexChatPanelProps, "state">> = (props) => 
     ...props.style,
   }}>
     {/* Scrollable message area: Figma layout_77BZNU - column, gap 16px, padding 0 8px */}
-    <div style={{
-      flex: "1",
-      "overflow-y": "auto",
+    <div
+      aria-live="polite"
+      style={{
+        flex: "1",
+        "overflow-y": "auto",
       display: "flex",
       "flex-direction": "column",
       gap: "16px",


### PR DESCRIPTION
This PR adds `aria-live="polite"` to the chat messages container, ensuring that new streaming messages are announced by screen readers. Resolves accessibility issue #28404 in PlatformNetwork/bounty-challenge.