### PR TITLE
feat: additional accessibility improvements

### DIFF
--- a/src/components/CommandCenter.tsx
+++ b/src/components/CommandCenter.tsx
@@ -476,6 +476,7 @@ export function CommandCenter() {
       {/* Input Field */}
       <Show when={isFocused() || isExpanded()}>
         <input
+          aria-label="Search commands"
           ref={inputRef}
           type="text"
           value={query()}

--- a/src/components/cortex/EnhancedStatusBar.tsx
+++ b/src/components/cortex/EnhancedStatusBar.tsx
@@ -115,9 +115,9 @@ export const EnhancedStatusBar: Component<EnhancedStatusBarProps> = (props) => {
             }}
             onClick={handleDiagnosticsClick}
           >
-            <CortexIcon name="circle-xmark" size={12} />
+            <CortexIcon name="circle-xmark" size={12} aria-hidden="true" />
             <span>{diagnosticCounts().error}</span>
-            <CortexIcon name="triangle-exclamation" size={12} />
+            <CortexIcon name="triangle-exclamation" size={12} aria-hidden="true" />
             <span>{diagnosticCounts().warning}</span>
           </div>
         </CortexTooltip>
@@ -125,7 +125,7 @@ export const EnhancedStatusBar: Component<EnhancedStatusBarProps> = (props) => {
         <Show when={statusBar.branchName()}>
           <CortexTooltip content={`Git Branch: ${statusBar.branchName()}`} position="top">
             <div style={itemStyle} onClick={handleBranchClick}>
-              <CortexIcon name="code-branch" size={12} />
+              <CortexIcon name="code-branch" size={12} aria-hidden="true" />
               <span>{statusBar.branchName()}</span>
               <Show when={statusBar.hasChanges()}>
                 <span style={{ color: "var(--cortex-warning)" }}>*</span>
@@ -144,7 +144,7 @@ export const EnhancedStatusBar: Component<EnhancedStatusBarProps> = (props) => {
               }}
               onClick={handleTrustClick}
             >
-              <CortexIcon name="shield-exclamation" size={12} />
+              <CortexIcon name="shield-exclamation" size={12} aria-hidden="true" />
               <span>Restricted</span>
             </div>
           </CortexTooltip>
@@ -226,7 +226,7 @@ export const EnhancedStatusBar: Component<EnhancedStatusBarProps> = (props) => {
             }}
             onClick={handleNotificationsClick}
           >
-            <CortexIcon name="bell" size={14} />
+            <CortexIcon name="bell" size={14} aria-hidden="true" />
             <Show when={statusBar.notificationCount() > 0}>
               <span
                 style={{
@@ -281,7 +281,7 @@ const StatusBarItem: Component<StatusBarItemProps> = (props) => {
       aria-label={props.item.accessibilityLabel || props.item.tooltip}
     >
       <Show when={props.item.icon}>
-        <CortexIcon name={props.item.icon!} size={12} />
+        <CortexIcon name={props.item.icon!} size={12} aria-hidden="true" />
       </Show>
       <Show when={props.item.text}>
         <span>{props.item.text}</span>

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -91,6 +91,7 @@ export const ConfirmDialog: Component<ConfirmDialogProps> = (props) => {
       <div style={bodyStyle}>
         <div style={iconContainerStyle}>
           <CortexIcon
+            aria-hidden="true"
             name="triangle-exclamation"
             size={20}
             style={{ color: "var(--cortex-warning, #F59E0B)" }}


### PR DESCRIPTION
This PR implements further accessibility fixes across the IDE:
1. Added `aria-hidden="true"` to decorative icons in `EnhancedStatusBar` and `ConfirmDialog`.
2. Added `aria-label="Search commands"` to the `CommandCenter` search input.

Resolves issues #28441, #28442, and #28443 in PlatformNetwork/bounty-challenge.