### PR TITLE
fix(a11y): add missing aria-labels to lists in CommandPalette, GoToSymbolDialog, SubAgentManager

### DIFF
--- a/src/components/CommandCenter.tsx
+++ b/src/components/CommandCenter.tsx
@@ -476,6 +476,7 @@ export function CommandCenter() {
       {/* Input Field */}
       <Show when={isFocused() || isExpanded()}>
         <input
+          aria-label="Search commands"
           ref={inputRef}
           type="text"
           value={query()}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -381,6 +381,7 @@ export function CommandPalette() {
         <div 
           id="quick-input-list"
           role="listbox"
+          aria-label="Command palette options"
           style={{ "line-height": "18px" }}
         >
           <div 

--- a/src/components/ai/SubAgentManager.tsx
+++ b/src/components/ai/SubAgentManager.tsx
@@ -361,7 +361,7 @@ export function SubAgentManager() {
             </div>
             
             {/* Agent List */}
-            <div class="flex-1 overflow-auto">
+            <div class="flex-1 overflow-auto" aria-label="Sub-agents" role="region">
               <Show when={builtInAgents().length > 0}>
                 <div class="px-3 py-1.5 text-[10px] font-medium uppercase" style={{ color: "var(--text-weaker)" }}>
                   Built-in

--- a/src/components/cortex/EnhancedStatusBar.tsx
+++ b/src/components/cortex/EnhancedStatusBar.tsx
@@ -115,9 +115,9 @@ export const EnhancedStatusBar: Component<EnhancedStatusBarProps> = (props) => {
             }}
             onClick={handleDiagnosticsClick}
           >
-            <CortexIcon name="circle-xmark" size={12} />
+            <CortexIcon name="circle-xmark" size={12} aria-hidden="true" />
             <span>{diagnosticCounts().error}</span>
-            <CortexIcon name="triangle-exclamation" size={12} />
+            <CortexIcon name="triangle-exclamation" size={12} aria-hidden="true" />
             <span>{diagnosticCounts().warning}</span>
           </div>
         </CortexTooltip>
@@ -125,7 +125,7 @@ export const EnhancedStatusBar: Component<EnhancedStatusBarProps> = (props) => {
         <Show when={statusBar.branchName()}>
           <CortexTooltip content={`Git Branch: ${statusBar.branchName()}`} position="top">
             <div style={itemStyle} onClick={handleBranchClick}>
-              <CortexIcon name="code-branch" size={12} />
+              <CortexIcon name="code-branch" size={12} aria-hidden="true" />
               <span>{statusBar.branchName()}</span>
               <Show when={statusBar.hasChanges()}>
                 <span style={{ color: "var(--cortex-warning)" }}>*</span>
@@ -144,7 +144,7 @@ export const EnhancedStatusBar: Component<EnhancedStatusBarProps> = (props) => {
               }}
               onClick={handleTrustClick}
             >
-              <CortexIcon name="shield-exclamation" size={12} />
+              <CortexIcon name="shield-exclamation" size={12} aria-hidden="true" />
               <span>Restricted</span>
             </div>
           </CortexTooltip>
@@ -226,7 +226,7 @@ export const EnhancedStatusBar: Component<EnhancedStatusBarProps> = (props) => {
             }}
             onClick={handleNotificationsClick}
           >
-            <CortexIcon name="bell" size={14} />
+            <CortexIcon name="bell" size={14} aria-hidden="true" />
             <Show when={statusBar.notificationCount() > 0}>
               <span
                 style={{
@@ -281,7 +281,7 @@ const StatusBarItem: Component<StatusBarItemProps> = (props) => {
       aria-label={props.item.accessibilityLabel || props.item.tooltip}
     >
       <Show when={props.item.icon}>
-        <CortexIcon name={props.item.icon!} size={12} />
+        <CortexIcon name={props.item.icon!} size={12} aria-hidden="true" />
       </Show>
       <Show when={props.item.text}>
         <span>{props.item.text}</span>

--- a/src/components/cortex/command-palette/CortexCommandPalette.tsx
+++ b/src/components/cortex/command-palette/CortexCommandPalette.tsx
@@ -215,7 +215,7 @@ export function CortexCommandPalette() {
             onInput={(e) => palette.setQuery(e.currentTarget.value)} onKeyDown={handleKeyDown}
             aria-haspopup="listbox" aria-autocomplete="list" aria-controls="cortex-palette-list" style={inputStyle} />
         </div>
-        <div id="cortex-palette-list" role="listbox" ref={listRef} style={listStyle}>
+        <div id="cortex-palette-list" role="listbox" aria-label="Command palette options" ref={listRef} style={listStyle}>
           <Show when={flatList().length === 0}>
             <div style={emptyStyle}>No commands found</div>
           </Show>

--- a/src/components/cortex/dialogs/GoToSymbolDialog.tsx
+++ b/src/components/cortex/dialogs/GoToSymbolDialog.tsx
@@ -158,7 +158,7 @@ export function GoToSymbolDialog() {
           </div>
         </div>
         <div class="quick-input-progress"><div class="progress-bit" /></div>
-        <div class="quick-input-list" id="symbol-picker-list" role="listbox">
+        <div class="quick-input-list" id="symbol-picker-list" role="listbox" aria-label="Symbol list">
           <div ref={listRef} class="list-container" style={{ "max-height": "440px", overflow: "auto", "overscroll-behavior": "contain" }}>
             <Show when={outlineState.loading}>
               <div style={{ padding: "16px", "text-align": "center" }}>

--- a/src/components/palette/CommandPalette.tsx
+++ b/src/components/palette/CommandPalette.tsx
@@ -210,7 +210,7 @@ export function PaletteCommandPalette() {
             onInput={e => setQuery(e.currentTarget.value)} onKeyDown={handleKeyDown}
             style={{ flex: "1", height: "18px", background: "transparent", border: "none", outline: "none", color: "var(--jb-text-body-color)", "font-size": "11px" }} />
         </div>
-        <div role="listbox" style={{ "line-height": "18px" }}>
+        <div role="listbox" aria-label="Command palette options" style={{ "line-height": "18px" }}>
           <div ref={listRef} style={{ "max-height": "280px", overflow: "auto", "overscroll-behavior": "contain", "padding-bottom": "3px" }}>
             <Show when={flatList().length === 0}>
               <div style={{ padding: "10px", "text-align": "center", "font-size": "10px", color: "var(--jb-text-muted-color)" }}>No commands found</div>

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -91,6 +91,7 @@ export const ConfirmDialog: Component<ConfirmDialogProps> = (props) => {
       <div style={bodyStyle}>
         <div style={iconContainerStyle}>
           <CortexIcon
+            aria-hidden="true"
             name="triangle-exclamation"
             size={20}
             style={{ color: "var(--cortex-warning, #F59E0B)" }}


### PR DESCRIPTION
Resolves #29427, #29419, and #29410 by adding the necessary `aria-label` attributes to scrollable listbox and region elements for screen reader support.