### PR TITLE
fix(a11y): add missing aria-labels to lists in various components

### DIFF
--- a/src/components/CommandCenter.tsx
+++ b/src/components/CommandCenter.tsx
@@ -476,6 +476,7 @@ export function CommandCenter() {
       {/* Input Field */}
       <Show when={isFocused() || isExpanded()}>
         <input
+          aria-label="Search commands"
           ref={inputRef}
           type="text"
           value={query()}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -381,6 +381,7 @@ export function CommandPalette() {
         <div 
           id="quick-input-list"
           role="listbox"
+          aria-label="Command palette options"
           style={{ "line-height": "18px" }}
         >
           <div 

--- a/src/components/FileFinder.tsx
+++ b/src/components/FileFinder.tsx
@@ -1008,11 +1008,11 @@ export function FileFinder() {
         </Show>
 
         {/* Results list - Design specs: max-height 400px */}
-        <div 
+        <div
           id="file-finder-list"
           role="listbox"
-          style={{
-            "max-height": "400px",
+          aria-label="File finder results"
+          style={{            "max-height": "400px",
             overflow: "auto",
             "overscroll-behavior": "contain",
           }}

--- a/src/components/Journal.tsx
+++ b/src/components/Journal.tsx
@@ -426,7 +426,7 @@ export function JournalPanel() {
               </div>
 
               {/* Search results */}
-              <div class="flex-1 overflow-y-auto">
+              <div class="flex-1 overflow-y-auto" role="region" aria-label="Entries list">
                 <Show when={journal.state.isSearching}>
                   <div class="p-4 text-center">
                     <div class="animate-spin w-6 h-6 border-2 border-current border-t-transparent rounded-full mx-auto" style={{ color: "var(--accent-primary)" }} />

--- a/src/components/ai/SubAgentManager.tsx
+++ b/src/components/ai/SubAgentManager.tsx
@@ -361,7 +361,7 @@ export function SubAgentManager() {
             </div>
             
             {/* Agent List */}
-            <div class="flex-1 overflow-auto">
+            <div class="flex-1 overflow-auto" aria-label="Sub-agents" role="region">
               <Show when={builtInAgents().length > 0}>
                 <div class="px-3 py-1.5 text-[10px] font-medium uppercase" style={{ color: "var(--text-weaker)" }}>
                   Built-in

--- a/src/components/cortex/EnhancedStatusBar.tsx
+++ b/src/components/cortex/EnhancedStatusBar.tsx
@@ -115,9 +115,9 @@ export const EnhancedStatusBar: Component<EnhancedStatusBarProps> = (props) => {
             }}
             onClick={handleDiagnosticsClick}
           >
-            <CortexIcon name="circle-xmark" size={12} />
+            <CortexIcon name="circle-xmark" size={12} aria-hidden="true" />
             <span>{diagnosticCounts().error}</span>
-            <CortexIcon name="triangle-exclamation" size={12} />
+            <CortexIcon name="triangle-exclamation" size={12} aria-hidden="true" />
             <span>{diagnosticCounts().warning}</span>
           </div>
         </CortexTooltip>
@@ -125,7 +125,7 @@ export const EnhancedStatusBar: Component<EnhancedStatusBarProps> = (props) => {
         <Show when={statusBar.branchName()}>
           <CortexTooltip content={`Git Branch: ${statusBar.branchName()}`} position="top">
             <div style={itemStyle} onClick={handleBranchClick}>
-              <CortexIcon name="code-branch" size={12} />
+              <CortexIcon name="code-branch" size={12} aria-hidden="true" />
               <span>{statusBar.branchName()}</span>
               <Show when={statusBar.hasChanges()}>
                 <span style={{ color: "var(--cortex-warning)" }}>*</span>
@@ -144,7 +144,7 @@ export const EnhancedStatusBar: Component<EnhancedStatusBarProps> = (props) => {
               }}
               onClick={handleTrustClick}
             >
-              <CortexIcon name="shield-exclamation" size={12} />
+              <CortexIcon name="shield-exclamation" size={12} aria-hidden="true" />
               <span>Restricted</span>
             </div>
           </CortexTooltip>
@@ -226,7 +226,7 @@ export const EnhancedStatusBar: Component<EnhancedStatusBarProps> = (props) => {
             }}
             onClick={handleNotificationsClick}
           >
-            <CortexIcon name="bell" size={14} />
+            <CortexIcon name="bell" size={14} aria-hidden="true" />
             <Show when={statusBar.notificationCount() > 0}>
               <span
                 style={{
@@ -281,7 +281,7 @@ const StatusBarItem: Component<StatusBarItemProps> = (props) => {
       aria-label={props.item.accessibilityLabel || props.item.tooltip}
     >
       <Show when={props.item.icon}>
-        <CortexIcon name={props.item.icon!} size={12} />
+        <CortexIcon name={props.item.icon!} size={12} aria-hidden="true" />
       </Show>
       <Show when={props.item.text}>
         <span>{props.item.text}</span>

--- a/src/components/cortex/command-palette/CortexCommandPalette.tsx
+++ b/src/components/cortex/command-palette/CortexCommandPalette.tsx
@@ -215,7 +215,7 @@ export function CortexCommandPalette() {
             onInput={(e) => palette.setQuery(e.currentTarget.value)} onKeyDown={handleKeyDown}
             aria-haspopup="listbox" aria-autocomplete="list" aria-controls="cortex-palette-list" style={inputStyle} />
         </div>
-        <div id="cortex-palette-list" role="listbox" ref={listRef} style={listStyle}>
+        <div id="cortex-palette-list" role="listbox" aria-label="Command palette options" ref={listRef} style={listStyle}>
           <Show when={flatList().length === 0}>
             <div style={emptyStyle}>No commands found</div>
           </Show>

--- a/src/components/cortex/dialogs/GoToSymbolDialog.tsx
+++ b/src/components/cortex/dialogs/GoToSymbolDialog.tsx
@@ -158,7 +158,7 @@ export function GoToSymbolDialog() {
           </div>
         </div>
         <div class="quick-input-progress"><div class="progress-bit" /></div>
-        <div class="quick-input-list" id="symbol-picker-list" role="listbox">
+        <div class="quick-input-list" id="symbol-picker-list" role="listbox" aria-label="Symbol list">
           <div ref={listRef} class="list-container" style={{ "max-height": "440px", overflow: "auto", "overscroll-behavior": "contain" }}>
             <Show when={outlineState.loading}>
               <div style={{ padding: "16px", "text-align": "center" }}>

--- a/src/components/cortex/editor/QuickPickMenu.tsx
+++ b/src/components/cortex/editor/QuickPickMenu.tsx
@@ -242,7 +242,7 @@ export const QuickPickMenu: Component<QuickPickMenuProps> = (props) => {
               </div>
             </Show>
 
-            <div style={listStyle}>
+            <div style={listStyle} role="listbox" aria-label="Quick pick items">
               <Show
                 when={filteredItems().length > 0}
                 fallback={<div style={emptyStyle}>No matching items</div>}

--- a/src/components/dev/ProcessExplorer.tsx
+++ b/src/components/dev/ProcessExplorer.tsx
@@ -1357,7 +1357,8 @@ Process List:
                   </div>
                 }
               >
-                <table class="w-full">
+                <table class="w-full" aria-label="Process list">
+                  <caption class="sr-only">List of running processes</caption>
                   <thead
                     class="sticky top-0 z-10"
                     style={{ background: isDark() ? "var(--cortex-bg-secondary)" : "var(--cortex-text-primary)" }}

--- a/src/components/palette/CommandPalette.tsx
+++ b/src/components/palette/CommandPalette.tsx
@@ -210,7 +210,7 @@ export function PaletteCommandPalette() {
             onInput={e => setQuery(e.currentTarget.value)} onKeyDown={handleKeyDown}
             style={{ flex: "1", height: "18px", background: "transparent", border: "none", outline: "none", color: "var(--jb-text-body-color)", "font-size": "11px" }} />
         </div>
-        <div role="listbox" style={{ "line-height": "18px" }}>
+        <div role="listbox" aria-label="Command palette options" style={{ "line-height": "18px" }}>
           <div ref={listRef} style={{ "max-height": "280px", overflow: "auto", "overscroll-behavior": "contain", "padding-bottom": "3px" }}>
             <Show when={flatList().length === 0}>
               <div style={{ padding: "10px", "text-align": "center", "font-size": "10px", color: "var(--jb-text-muted-color)" }}>No commands found</div>

--- a/src/components/settings/KeymapEditor.tsx
+++ b/src/components/settings/KeymapEditor.tsx
@@ -326,7 +326,7 @@ export function KeymapEditor(_props: KeymapEditorProps) {
       </div>
 
       {/* Keybindings list - VS Code keybindings table container */}
-      <div class="keybindings-table-container flex-1 overflow-y-auto rounded-b-lg border-x border-b border-border">
+      <div class="keybindings-table-container flex-1 overflow-y-auto rounded-b-lg border-x border-b border-border" role="region" aria-label="Keybindings list">
         <Show
           when={groupedBindings().length > 0}
           fallback={

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -91,6 +91,7 @@ export const ConfirmDialog: Component<ConfirmDialogProps> = (props) => {
       <div style={bodyStyle}>
         <div style={iconContainerStyle}>
           <CortexIcon
+            aria-hidden="true"
             name="triangle-exclamation"
             size={20}
             style={{ color: "var(--cortex-warning, #F59E0B)" }}


### PR DESCRIPTION
Resolves #29435, #29431, #29391, #29387, and #29382 by adding the necessary `aria-label` attributes to scrollable listbox and region elements for screen reader support.